### PR TITLE
Setuptools-entry-point

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,3 +10,7 @@ replace = version = "{new_version}"
 [bumpversion:file:biotope/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
+
+[bumpversion:file:biotope/cli.py]
+search = @click.version_option(version="{current_version}")
+replace = @click.version_option(version="{new_version}")

--- a/biotope/__main__.py
+++ b/biotope/__main__.py
@@ -1,0 +1,6 @@
+"""Main entry point for biotope CLI."""
+
+from biotope.cli import cli
+
+if __name__ == "__main__":
+    cli() 

--- a/biotope/cli.py
+++ b/biotope/cli.py
@@ -18,12 +18,12 @@ from biotope.commands.status import status as status_cmd
 
 
 @click.group()
-@click.version_option(version="0.1.0")
+@click.version_option(version="0.3.0")
 @click.pass_context
 def cli(ctx: click.Context) -> None:
     """CLI entrypoint."""
     ctx.ensure_object(dict)
-    ctx.obj = {"version": "0.1.0"}
+    ctx.obj = {"version": "0.3.0"}
 
 
 cli.add_command(init_cmd, "init")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ Documentation = "https://biocypher.org"
 Download = "https://pypi.org/project/biotope/#files"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<3.14"
 click = "^8.1.8"
 rich = "^13.9.4"
 PyYAML = "^6.0"


### PR DESCRIPTION
Sync CLI Version with bumpversion
Added a [bumpversion:file:biotope/cli.py] section to .bumpversion.cfg
Ensures the CLI version in @click.version_option is updated automatically with each version bump
Keeps pyproject.toml, biotope/__init__.py, and biotope/cli.py versions in sync