### PR TITLE
Adding the support for batch file annotation using a csv file

### DIFF
--- a/biotope/commands/add.py
+++ b/biotope/commands/add.py
@@ -129,7 +129,7 @@ def _add_file(
     metadata = {
         "@context": {"@vocab": "https://schema.org/"},
         "@type": "Dataset",
-        "name": file_path.stem,
+        "name": str(file_path.relative_to(biotope_root)),
         "description": f"Dataset for {file_path.name}",
         "distribution": [
             {

--- a/biotope/commands/add.py
+++ b/biotope/commands/add.py
@@ -1,6 +1,7 @@
 """Add command implementation for tracking data files and metadata."""
 
 import json
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -99,15 +100,6 @@ def add(paths: tuple[Path, ...], recursive: bool, force: bool) -> None:
         for file_path in skipped_files:
             click.echo(f"  - {file_path}")
 
-    if added_files:
-        click.echo(f"\n💡 Next steps:")
-        click.echo(f"  1. Run 'biotope status' to see staged files")
-        click.echo(
-            f"  2. Run 'biotope annotate interactive --staged' to create metadata"
-        )
-        click.echo(f"  3. Run 'biotope commit -m \"message\"' to save changes")
-
-
 def _add_file(
     file_path: Path, biotope_root: Path, datasets_dir: Path, force: bool
 ) -> bool:
@@ -122,7 +114,7 @@ def _add_file(
 
     # Check if already tracked
     if not force and is_file_tracked(file_path, biotope_root):
-        click.echo(f"⚠️  File '{file_path}' already tracked (use --force to override)")
+        click.echo(f"⚠️  File {file_path.relative_to(biotope_root)} already tracked (use --force to override)")
         return False
 
     # Create basic metadata entry
@@ -144,6 +136,22 @@ def _add_file(
         ],
     }
 
+    metadata["dateCreated"] = datetime.now(timezone.utc).isoformat()
+
+    # Top-level creator (from git, if available)
+    git_name, git_email = _git_user_identity(biotope_root)
+    if git_name:
+        creator_obj = {"@type": "Person", "name": git_name}
+        if git_email:
+            creator_obj["email"] = git_email
+        metadata["creator"] = creator_obj
+    else:
+        click.echo(
+            "ℹ️  No Git identity found. Set it once to prefill 'creator' automatically:\n"
+            "    git config --global user.name  \"Your Name\"\n"
+            "    git config --global user.email \"you@example.com\""
+        )
+
     # Save metadata to datasets directory with directory structure mirroring
     relative_path = file_path.relative_to(biotope_root)
     metadata_file = datasets_dir / relative_path.with_suffix(".jsonld")
@@ -151,5 +159,21 @@ def _add_file(
     with open(metadata_file, "w") as f:
         json.dump(metadata, f, indent=2)
 
-    click.echo(f"📁 Added {file_path} (SHA256: {sha256_hash[:8]}...)")
     return True
+
+def _git_user_identity(cwd: Path) -> tuple[str | None, str | None]:
+    """Return (name, email) from `git config`, preferring repo-local config."""
+    try:
+        name = subprocess.run(
+            ["git", "config", "--get", "user.name"],
+            cwd=cwd,
+            capture_output=True, text=True, check=False
+        ).stdout.strip() or None
+        email = subprocess.run(
+            ["git", "config", "--get", "user.email"],
+            cwd=cwd,
+            capture_output=True, text=True, check=False
+        ).stdout.strip() or None
+        return name, email
+    except FileNotFoundError:
+        return None, None

--- a/biotope/commands/add.py
+++ b/biotope/commands/add.py
@@ -1,9 +1,11 @@
 """Add command implementation for tracking data files and metadata."""
 
+import csv
 import json
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import List
 
 import click
 
@@ -12,6 +14,7 @@ from biotope.utils import (
     is_git_repo,
     stage_git_changes,
     calculate_file_checksum,
+    load_project_metadata,
     is_file_tracked,
 )
 
@@ -89,6 +92,11 @@ def add(paths: tuple[Path, ...], recursive: bool, force: bool) -> None:
     if added_files:
         stage_git_changes(biotope_root)
 
+    # Generate .biotope.csv if appropriate
+    if _should_generate_csv(paths, recursive, added_files):
+        target_directory = paths[0]  # We know there's exactly one directory
+        _generate_biotope_csv(target_directory, added_files, biotope_root)
+
     # Report results
     if added_files:
         click.echo(f"\n✅ Added {len(added_files)} file(s) to biotope project:")
@@ -99,6 +107,23 @@ def add(paths: tuple[Path, ...], recursive: bool, force: bool) -> None:
         click.echo(f"\n⚠️  Skipped {len(skipped_files)} file(s):")
         for file_path in skipped_files:
             click.echo(f"  - {file_path}")
+
+    if added_files:
+        click.echo(f"\n💡 Next steps:")
+        
+        # Check if we generated a CSV file and adjust instructions
+        if _should_generate_csv(paths, recursive, added_files):
+            target_directory = paths[0]
+            csv_path = target_directory / ".biotope.csv"
+            click.echo(f"  1. Edit the generated CSV file: {csv_path}")
+            click.echo(f"  2. Run 'biotope annotate batch --from-csv {csv_path}' to apply annotations")
+            click.echo(f"  3. Run 'biotope commit -m \"message\"' to save changes")
+        else:
+            click.echo(f"  1. Run 'biotope status' to see staged files")
+            click.echo(
+                f"  2. Run 'biotope annotate interactive --staged' to create metadata"
+            )
+            click.echo(f"  3. Run 'biotope commit -m \"message\"' to save changes")
 
 def _add_file(
     file_path: Path, biotope_root: Path, datasets_dir: Path, force: bool
@@ -131,12 +156,12 @@ def _add_file(
                 "contentUrl": str(file_path.relative_to(biotope_root)),
                 "sha256": sha256_hash,
                 "contentSize": file_path.stat().st_size,
-                "dateCreated": datetime.now(timezone.utc).isoformat(),
+                "dateCreated": datetime.now(tz=timezone.utc).isoformat(),
             }
         ],
     }
 
-    metadata["dateCreated"] = datetime.now(timezone.utc).isoformat()
+    metadata["dateCreated"] = datetime.now(tz=timezone.utc).isoformat()
 
     # Top-level creator (from git, if available)
     git_name, git_email = _git_user_identity(biotope_root)
@@ -151,6 +176,17 @@ def _add_file(
             "    git config --global user.name  \"Your Name\"\n"
             "    git config --global user.email \"you@example.com\""
         )
+
+    # Inject project-level defaults for common metadata so later CSV import is a no-op
+    try:
+        project_defaults = load_project_metadata(biotope_root)
+        for key in ("license", "citation", "cr:projectName"):
+            value = project_defaults.get(key)
+            if value and key not in metadata:
+                metadata[key] = value
+    except Exception:
+        # If project metadata cannot be loaded, proceed without it
+        pass
 
     # Save metadata to datasets directory with directory structure mirroring
     relative_path = file_path.relative_to(biotope_root)
@@ -168,12 +204,193 @@ def _git_user_identity(cwd: Path) -> tuple[str | None, str | None]:
             ["git", "config", "--get", "user.name"],
             cwd=cwd,
             capture_output=True, text=True, check=False
-        ).stdout.strip() or None
+        ).stdout.strip()
         email = subprocess.run(
             ["git", "config", "--get", "user.email"],
             cwd=cwd,
             capture_output=True, text=True, check=False
-        ).stdout.strip() or None
-        return name, email
+        ).stdout.strip()
+
+        def _normalize(value: object) -> str | None:
+            try:
+                # Coerce to string and strip; ensure empty strings become None
+                text = value if isinstance(value, str) else str(value)
+                text = text.strip()
+                return text or None
+            except Exception:
+                return None
+
+        return _normalize(name), _normalize(email)
     except FileNotFoundError:
         return None, None
+
+
+def _generate_biotope_csv(directory: Path, added_files: List[Path], biotope_root: Path) -> None:
+    """
+    Generate a .biotope.csv file with pre-filled metadata from added files.
+    
+    Args:
+        directory: The directory where files were added from
+        added_files: List of files that were added to biotope
+        biotope_root: Root of the biotope project
+    """
+    datasets_dir = biotope_root / ".biotope" / "datasets"
+    csv_path = directory / ".biotope.csv"
+    
+    # Define all possible CSV columns with their descriptions
+    csv_columns = [
+        "filepath",  # Required
+        "name",  # Can be derived from filepath
+        "description",  # Required
+        "data_url",  # Optional - URL to data source
+        "creator",  # Optional - Contact person/creator
+        "project_name",  # Optional
+        "date_created",  # Can be derived from jsonld
+        "access_restrictions",  # Optional
+        "encoding_format",  # Optional - file format
+        "legal_obligations",  # Optional
+        "collaboration_partner",  # Optional
+        "publication_date",  # Optional
+        "version",  # Optional
+        "license_url",  # Optional
+        "citation",  # Optional
+    ]
+    
+    csv_rows = []
+    
+    # Filter added files to only those in the target directory
+    # added_files contains relative paths, directory is also relative
+    directory_str = str(directory)
+    directory_files = []
+    for f in added_files:
+        file_str = str(f)
+        # Check if the file is within the target directory
+        if file_str.startswith(directory_str + "/") or file_str == directory_str:
+            directory_files.append(f)
+    
+    for file_path in directory_files:
+        # Load existing metadata if available
+        # file_path is relative to current working directory, convert to absolute then relative to biotope_root
+        try:
+            # file_path is relative, so resolve it first
+            abs_file_path = (Path.cwd() / file_path).resolve()
+            relative_path = abs_file_path.relative_to(biotope_root)
+        except ValueError:
+            # If file_path is not under biotope_root, skip it
+            continue
+        metadata_file = datasets_dir / relative_path.with_suffix(".jsonld")
+        
+        metadata = {}
+        if metadata_file.exists():
+            try:
+                with open(metadata_file, 'r') as f:
+                    metadata = json.load(f)
+            except Exception:
+                pass  # Use empty metadata if can't load
+        
+        # Extract information from metadata
+        row = {}
+        
+        # Filepath (relative to biotope root)
+        row["filepath"] = str(relative_path)
+        
+        # Name (from metadata or derive from filename)
+        row["name"] = metadata.get("name", file_path.stem)
+        
+        # Description (from metadata or default)
+        row["description"] = metadata.get("description", f"Dataset for {file_path.name}")
+        
+        # Extract date from distribution if available
+        distribution = metadata.get("distribution", [])
+        if distribution and isinstance(distribution, list) and len(distribution) > 0:
+            date_created = distribution[0].get("dateCreated", "")
+            if date_created:
+                # Convert from ISO format to date only
+                try:
+                    parsed_date = datetime.fromisoformat(date_created.replace('Z', '+00:00'))
+                    row["date_created"] = parsed_date.strftime("%Y-%m-%d")
+                except Exception:
+                    row["date_created"] = ""
+            else:
+                row["date_created"] = ""
+        else:
+            row["date_created"] = ""
+        
+        # Extract creator information if available
+        creator = metadata.get("creator", {})
+        if isinstance(creator, dict):
+            row["creator"] = creator.get("name", "")
+        else:
+            row["creator"] = ""
+        
+        if not row.get("date_created"):
+            row["date_created"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        if not row.get("creator"):
+            git_name, _git_email = _git_user_identity(biotope_root)
+            if git_name:
+                row["creator"] = git_name
+        
+        # Extract other metadata fields
+        row["data_url"] = metadata.get("url", "")
+        row["project_name"] = ""  # This would come from project metadata
+        row["access_restrictions"] = metadata.get("cr:accessRestrictions", "")
+        row["encoding_format"] = metadata.get("encodingFormat", "")
+        row["legal_obligations"] = metadata.get("cr:legalObligations", "")
+        row["collaboration_partner"] = metadata.get("cr:collaborationPartner", "")
+        row["publication_date"] = metadata.get("datePublished", "")
+        row["version"] = metadata.get("version", "")
+        row["license_url"] = metadata.get("license", "")
+        row["citation"] = metadata.get("citation", "")
+        
+        csv_rows.append(row)
+    
+    # Write CSV file if we have files to process
+    if csv_rows:
+        try:
+            with open(csv_path, 'w', newline='', encoding='utf-8') as f:
+                writer = csv.DictWriter(f, fieldnames=csv_columns)
+                
+                # Write header
+                writer.writeheader()
+                
+                # Write data rows
+                for row in csv_rows:
+                    writer.writerow(row)
+            
+            click.echo(f"\n📝 Generated annotation template: {csv_path}")
+            click.echo("💡 Edit this file to add metadata, then run:")
+            click.echo(f"   biotope annotate batch --from-csv {csv_path}")
+            
+        except Exception as e:
+            click.echo(f"⚠️  Warning: Could not generate .biotope.csv: {e}")
+    else:
+        click.echo("ℹ️  No files added from this directory, skipping CSV generation")
+
+
+def _should_generate_csv(paths: tuple[Path, ...], recursive: bool, added_files: List[Path]) -> bool:
+    """
+    Determine if we should generate a .biotope.csv file.
+    
+    Returns True if:
+    - Recursive flag is used
+    - Only one directory was specified as input
+    - Files were actually added from that directory
+    """
+    if not recursive or not added_files:
+        return False
+    
+    # Check if exactly one directory was specified
+    if len(paths) == 1 and paths[0].is_dir():
+        # Check if all added files are from this directory or its subdirectories
+        target_dir = paths[0]  # Use relative path, not resolved
+        for file_path in added_files:
+            # Check if the file is within the target directory
+            # file_path should be relative to current working directory
+            file_path_str = str(file_path)
+            target_dir_str = str(target_dir)
+            if not (file_path_str.startswith(target_dir_str + "/") or file_path_str == target_dir_str):
+                return False  # File is not within the target directory
+        return True
+    
+    return False

--- a/biotope/commands/annotate.py
+++ b/biotope/commands/annotate.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import csv
 import datetime
 import getpass
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -337,6 +339,51 @@ def load(jsonld, record_set, num_records):
 
 @annotate.command()
 @click.option(
+    "--from-csv",
+    type=click.Path(exists=True),
+    help="Path to CSV file containing batch annotation data",
+)
+@click.option(
+    "--column-mapping",
+    "-m",
+    type=str,
+    help="JSON string mapping CSV column names to expected fields (e.g., '{\"data_file\": \"filepath\"}')",
+)
+def batch(
+    from_csv: str | None = None,
+    column_mapping: str | None = None
+) -> None:
+    """Batch annotate multiple files from a CSV file.
+    
+    This command updates the metadata for files that have already been added to the biotope project.
+    All files specified in the CSV must be already added/staged in the biotope project using 'biotope add'.
+    
+    The CSV should have columns for filepath, description, and other optional metadata.
+    The dataset name is automatically derived from the filepath.
+    Use --column-mapping to map your CSV columns to the expected metadata fields.
+    
+    Process:
+    1. Validates that all files in CSV are already staged in biotope
+    2. Finds the existing metadata files for those staged files
+    3. Updates the existing metadata with information from the CSV
+    
+    Examples:
+        biotope annotate batch --from-csv batch_data.csv
+        biotope annotate batch --from-csv my_data.csv --column-mapping '{"data_file": "filepath"}'
+    """
+    console = Console()
+
+    # Require CSV file
+    if not from_csv:
+        console.print("❌ CSV file is required. Use --from-csv option for help.")
+        raise click.Abort
+
+    # Handle CSV file processing
+    _process_csv_annotation(console, from_csv, column_mapping)
+
+
+@annotate.command()
+@click.option(
     "--file-path",
     "-f",
     type=click.Path(exists=True),
@@ -360,8 +407,26 @@ def load(jsonld, record_set, num_records):
     is_flag=True,
     help="Annotate all tracked files with incomplete metadata",
 )
-def interactive(file_path: str | None = None, prefill_metadata: str | None = None, staged: bool = False, incomplete: bool = False) -> None:
-    """Interactive annotation process for files."""
+def interactive(
+    file_path: str | None = None, 
+    prefill_metadata: str | None = None, 
+    staged: bool = False, 
+    incomplete: bool = False,
+) -> None:
+    """Interactive annotation process for files.
+    
+    This command supports multiple modes:
+    1. Single file annotation: --file-path
+    2. Staged files annotation: --staged
+    3. Incomplete files annotation: --incomplete
+    
+    For batch annotation from CSV files, use: biotope annotate batch --from-csv
+    
+    Examples:
+        biotope annotate interactive --file-path data.csv
+        biotope annotate interactive --staged
+        biotope annotate interactive --incomplete
+    """
     console = Console()
 
     # Initialize metadata with pre-filled values if provided
@@ -1223,6 +1288,310 @@ def _run_interactive_annotation(console: Console, file_path: Path, prefill_metad
         console.print(f"⚠️  Warning: Could not stage changes in Git: {e}")
 
 
+def _process_csv_annotation(
+    console: Console,
+    csv_file: str,
+    column_mapping: str | None = None,
+    biotope_root: Path | None = None
+) -> None:
+    """Process CSV file for batch annotation."""
+    
+    biotope_root = find_biotope_root()
+    if not biotope_root:
+        click.echo("❌ Not in a biotope project. Run 'biotope init' first.")
+        raise click.Abort
+    
+    console.print(f"[bold blue]Processing CSV file: {csv_file}[/]")
+    console.print("─" * 50)
+    
+    column_map = {}
+    if column_mapping:
+        try:
+            column_map = json.loads(column_mapping)
+        except json.JSONDecodeError:
+            console.print("❌ Invalid JSON in column mapping")
+            raise click.Abort
+    
+    # Define expected columns and their mappings
+    expected_columns = {
+        "filepath": "filepath",
+        "description": "description",
+        "data_url": "url",
+        "creator": "creator.name",
+        "project_name": "cr:projectName",
+        "date_created": "dateCreated",
+        "access_restrictions": "cr:accessRestrictions",
+        "encoding_format": "encodingFormat",
+        "legal_obligations": "cr:legalObligations",
+        "collaboration_partner": "cr:collaborationPartner",
+        "publication_date": "datePublished",
+        "version": "version",
+        "license": "license",
+        "citation": "citation"
+    }
+    
+    # Apply user's column mapping
+    if column_map:
+        for user_col, expected_col in column_map.items():
+            if expected_col in expected_columns:
+                expected_columns[user_col] = expected_columns[expected_col]
+                # Remove the original mapping if we're replacing it
+                if user_col != expected_col:
+                    expected_columns.pop(expected_col, None)
+    
+    try:
+        csv_path = Path(csv_file)
+        if not csv_path.exists():
+            console.print(f"❌ CSV file not found: {csv_file}")
+            raise click.Abort
+            
+        with open(csv_path, 'r', newline='', encoding='utf-8') as f:
+            # Try to detect the CSV dialect
+            sample = f.read(1024)
+            f.seek(0)
+            sniffer = csv.Sniffer()
+            dialect = sniffer.sniff(sample)
+            
+            reader = csv.DictReader(f, dialect=dialect)
+            rows = list(reader)
+            
+        if not rows:
+            console.print("❌ CSV file is empty")
+            raise click.Abort
+            
+        console.print(f"Found {len(rows)} entries in CSV file")
+        
+        # Validate that required columns exist
+        required_cols = ["filepath", "description"]
+        csv_columns = set(rows[0].keys())
+        
+        # Check if required columns exist (either directly or through mapping)
+        missing_required = []
+        for req_col in required_cols:
+            # Check if the column exists directly or through mapping
+            mapped_col = None
+            for csv_col, expected_col in expected_columns.items():
+                if expected_col == req_col and csv_col in csv_columns:
+                    mapped_col = csv_col
+                    break
+            
+            if mapped_col is None and req_col not in csv_columns:
+                missing_required.append(req_col)
+        
+        if missing_required:
+            console.print(f"❌ Missing required columns: {', '.join(missing_required)}")
+            console.print("Available columns:", ', '.join(csv_columns))
+            raise click.Abort
+        
+        # Get staged files to validate that CSV files are staged
+        staged_files = get_staged_files(biotope_root)
+        staged_file_paths = {info["file_path"] for info in staged_files}
+        
+        console.print(f"Found {len(staged_files)} staged files in project")
+        if staged_files:
+            console.print("Staged files:")
+            for info in staged_files:
+                console.print(f"   • {info['file_path']}")
+        
+        # Extract filenames from CSV and check if they're staged
+        csv_file_dir = Path(csv_file).parent
+        unstaged_files = []
+        csv_files_to_process = []
+        
+        for row in rows:
+            # Get filepath from row
+            filepath = None
+            for csv_col, expected_col in expected_columns.items():
+                if expected_col == "filepath" and csv_col in row:
+                    filepath = row[csv_col]
+                    break
+            
+            if not filepath:
+                filepath = row.get("filepath", "")
+            
+            if filepath:
+                # Check if file exists and has existing metadata (i.e., is staged)
+                existing_metadata_file = _find_existing_metadata_file(filepath, biotope_root, csv_file)
+                
+                if not existing_metadata_file:
+                    unstaged_files.append(filepath)
+                else:
+                    csv_files_to_process.append((filepath, row))
+        
+        if unstaged_files:
+            console.print(f"❌ The following files from CSV are not staged in biotope:")
+            for f in unstaged_files:
+                console.print(f"   • {f}")
+            console.print("\n💡 First add these files using:")
+            for f in unstaged_files:
+                console.print(f"   biotope add {f}")
+            console.print("\nThen try the annotation again.")
+            raise click.Abort
+        
+        # Process each validated file
+        successful_annotations = 0
+        for i, (filepath, row) in enumerate(csv_files_to_process, 1):
+            console.print(f"\n[bold green]Processing entry {i}/{len(csv_files_to_process)}[/]")
+            
+            try:
+                console.print(f"📁 File: {filepath}")
+                
+                # Build metadata from CSV row - pass filepath for default name generation
+                metadata = _build_metadata_from_csv_row(row, expected_columns, biotope_root, filepath)
+                
+                # Update existing annotation
+                _create_annotation_from_metadata(console, filepath, metadata, biotope_root, csv_file)
+                successful_annotations += 1
+                
+            except Exception as e:
+                console.print(f"❌ Error processing {filepath}: {e}")
+                continue
+        
+        console.print(f"\n✅ Successfully processed {successful_annotations}/{len(csv_files_to_process)} annotations")
+        
+        if successful_annotations > 0:
+            # Stage the changes in Git
+            try:
+                import subprocess
+                subprocess.run(
+                    ["git", "add", ".biotope/"],
+                    cwd=biotope_root,
+                    check=True
+                )
+                console.print("✅ Staged all changes in Git")
+            except subprocess.CalledProcessError as e:
+                console.print(f"⚠️  Warning: Could not stage changes in Git: {e}")
+        
+    except FileNotFoundError as e:
+        console.print(f"❌ File not found: {e}")
+        raise click.Abort
+    except Exception as e:
+        console.print(f"❌ Error processing CSV file: {e}")
+        raise click.Abort
+
+
+def _build_metadata_from_csv_row(row: dict, expected_columns: dict, biotope_root: Path, filepath: str) -> dict:
+    """Build metadata dictionary from CSV row."""
+    metadata = {}
+    
+    # Generate default name from filepath if name is not provided
+    default_name = Path(filepath).stem
+    
+    # Load project metadata for defaults
+    try:
+        from biotope.utils import load_project_metadata
+        project_metadata = load_project_metadata(biotope_root)
+    except:
+        project_metadata = {}
+    
+    # Map CSV columns to metadata fields
+    for csv_col, metadata_field in expected_columns.items():
+        if csv_col in row and row[csv_col].strip():
+            value = row[csv_col].strip()
+            
+            # Skip filepath field as it's not metadata
+            if metadata_field == "filepath":
+                continue
+            
+            # Handle nested fields (e.g., "creator.name")
+            if "." in metadata_field:
+                field_parts = metadata_field.split(".")
+                if field_parts[0] == "creator":
+                    if "creator" not in metadata:
+                        metadata["creator"] = {"@type": "Person"}
+                    metadata["creator"][field_parts[1]] = value
+            else:
+                metadata[metadata_field] = value
+    
+    # Use default name if name not provided
+    if "name" not in metadata or not metadata["name"]:
+        metadata["name"] = default_name
+    
+    # Apply defaults from project metadata for missing fields
+    for key, value in project_metadata.items():
+        if key not in metadata:
+            metadata[key] = value
+    
+    # Set required defaults if still missing
+    if "dateCreated" not in metadata:
+        metadata["dateCreated"] = datetime.date.today().isoformat()
+    
+    if "creator" not in metadata:
+        metadata["creator"] = {
+            "@type": "Person",
+            "name": getpass.getuser()
+        }
+    
+    return metadata
+
+
+def _create_annotation_from_metadata(console: Console, filepath: str, metadata: dict, biotope_root: Path, csv_file_path: str | None = None) -> None:
+    """Update existing metadata file for a staged file."""
+    # Find the existing metadata file for this staged file
+    existing_metadata_file = _find_existing_metadata_file(filepath, biotope_root, csv_file_path)
+    
+    if not existing_metadata_file:
+        console.print(f"❌ No existing metadata file found for '{filepath}'. File must be staged first with 'biotope add'.")
+        return
+    
+    # Load existing metadata
+    try:
+        with open(existing_metadata_file) as f:
+            existing_metadata = json.load(f)
+    except (json.JSONDecodeError, IOError) as e:
+        console.print(f"❌ Error reading existing metadata file {existing_metadata_file}: {e}")
+        return
+    
+    # Update existing metadata with new values from CSV, preserving distribution and other existing data
+    updated_metadata = existing_metadata.copy()
+    
+    # Update fields from CSV metadata, but preserve existing distribution
+    for key, value in metadata.items():
+        if key == "creator" and isinstance(value, dict):
+            # Handle creator object specially
+            if "creator" not in updated_metadata:
+                updated_metadata["creator"] = {"@type": "Person"}
+            updated_metadata["creator"].update(value)
+        elif key != "distribution":  # Don't overwrite distribution from existing file
+            updated_metadata[key] = value
+    
+    # Update encoding format in distribution if provided
+    if "encodingFormat" in metadata and "distribution" in updated_metadata:
+        for distribution in updated_metadata["distribution"]:
+            if distribution.get("@type") == "sc:FileObject":
+                distribution["encodingFormat"] = metadata["encodingFormat"]
+    
+    # Write updated metadata back to the same file
+    with open(existing_metadata_file, "w") as f:
+        json.dump(updated_metadata, f, indent=2)
+    
+    console.print(f"✅ Updated: {existing_metadata_file.relative_to(biotope_root)}")
+
+
+def _find_existing_metadata_file(filepath: str, biotope_root: Path, csv_file_path: str | None = None) -> Path | None:
+    """Find the existing metadata file for a given data file path."""
+    # Normalize the filepath from CSV to match what we're looking for
+    target_filepath = filepath.strip()
+    
+    # Search through all metadata files to find one that references this file in its distribution
+    datasets_dir = biotope_root / ".biotope" / "datasets"
+    if datasets_dir.exists():
+        for metadata_file in datasets_dir.rglob("*.jsonld"):
+            try:
+                with open(metadata_file) as f:
+                    metadata = json.load(f)
+                    for distribution in metadata.get("distribution", []):
+                        if distribution.get("@type") == "sc:FileObject":
+                            content_url = distribution.get("contentUrl", "")
+                            # Check if the contentUrl matches the filepath from CSV
+                            if content_url == target_filepath:
+                                return metadata_file
+            except (json.JSONDecodeError, IOError):
+                continue
+    
+    return None
+
+
 def get_staged_files(biotope_root: Path) -> list:
     """Get list of staged files from Git."""
     import json
@@ -1230,6 +1599,19 @@ def get_staged_files(biotope_root: Path) -> list:
     staged_files = []
     
     try:
+        # Get the git root directory to understand relative paths
+        git_root_result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=biotope_root,
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        git_root = Path(git_root_result.stdout.strip())
+        
+        # Calculate the relative path from git root to biotope root
+        biotope_relative_to_git = biotope_root.relative_to(git_root)
+        
         # Get staged files from Git
         result = subprocess.run(
             ["git", "diff", "--cached", "--name-only"],
@@ -1240,9 +1622,23 @@ def get_staged_files(biotope_root: Path) -> list:
         )
         
         for file_path in result.stdout.splitlines():
-            if file_path.startswith(".biotope/datasets/") and file_path.endswith(".jsonld"):
+            # Handle both cases: biotope project at git root and in subdirectory
+            if biotope_relative_to_git == Path("."):
+                # Biotope project is at git root
+                expected_prefix = ".biotope/datasets/"
+                metadata_file_path = file_path
+            else:
+                # Biotope project is in a subdirectory
+                expected_prefix = f"{biotope_relative_to_git}/.biotope/datasets/"
+                if file_path.startswith(str(biotope_relative_to_git) + "/"):
+                    # Strip the biotope relative path to get the path relative to biotope root
+                    metadata_file_path = file_path[len(str(biotope_relative_to_git)) + 1:]
+                else:
+                    continue
+            
+            if file_path.startswith(expected_prefix) and file_path.endswith(".jsonld"):
                 # Read the metadata file to get file information
-                metadata_file = biotope_root / file_path
+                metadata_file = biotope_root / metadata_file_path
                 try:
                     with open(metadata_file) as f:
                         metadata = json.load(f)

--- a/biotope/commands/annotate.py
+++ b/biotope/commands/annotate.py
@@ -1691,6 +1691,19 @@ def _build_metadata_from_csv_row(row: dict, expected_columns: dict, biotope_root
                     metadata["creator"][field_parts[1]] = value
             else:
                 metadata[metadata_field] = value
+
+    # Ensure creator name is captured even if mapping was altered or missing
+    try:
+        creator_val = row.get("creator", "").strip()
+        if creator_val:
+            if "creator" not in metadata or not isinstance(metadata.get("creator"), dict):
+                metadata["creator"] = {"@type": "Person", "name": creator_val}
+            else:
+                metadata["creator"]["name"] = creator_val
+                if "@type" not in metadata["creator"]:
+                    metadata["creator"]["@type"] = "Person"
+    except Exception:
+        pass
     
     # Use default name if name not provided
     if "name" not in metadata or not metadata["name"]:
@@ -1727,11 +1740,26 @@ def _create_annotation_from_metadata(
     
     # Update fields from CSV metadata, but preserve existing distribution
     for key, value in metadata.items():
-        if key == "creator" and isinstance(value, dict):
-            # Handle creator object specially
-            if "creator" not in updated_metadata:
-                updated_metadata["creator"] = {"@type": "Person"}
-            updated_metadata["creator"].update(value)
+        if key == "creator":
+            # Build a fresh creator object to avoid in-place mutation of nested dicts
+            if isinstance(value, dict):
+                existing_creator = (
+                    updated_metadata.get("creator")
+                    if isinstance(updated_metadata.get("creator"), dict)
+                    else {}
+                )
+                merged_creator = {"@type": "Person"}
+                # Preserve existing email if new one not provided
+                if isinstance(existing_creator, dict) and existing_creator.get("email"):
+                    merged_creator["email"] = existing_creator.get("email")
+                # Overlay incoming fields (name/email, etc.)
+                for k, v in value.items():
+                    merged_creator[k] = v
+                if "@type" not in merged_creator:
+                    merged_creator["@type"] = "Person"
+                updated_metadata["creator"] = merged_creator
+            elif isinstance(value, str) and value.strip():
+                updated_metadata["creator"] = {"@type": "Person", "name": value.strip()}
         elif key != "distribution":  # Don't overwrite distribution from existing file
             updated_metadata[key] = value
     

--- a/biotope/commands/annotate.py
+++ b/biotope/commands/annotate.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import csv
-import datetime
 import getpass
-import hashlib
 import json
 import subprocess
 from pathlib import Path
-from typing import Optional
+from datetime import datetime, timezone
 
 import click
 from rich.console import Console
@@ -77,9 +75,77 @@ def merge_metadata(dynamic_metadata: dict) -> dict:
     return metadata
 
 
-@click.group()
-def annotate() -> None:
-    """Create dataset metadata definitions in Croissant format."""
+@click.group(invoke_without_command=True)
+@click.option(
+    "-r",
+    "--recursive",
+    is_flag=True,
+    help="Shorthand for 'annotate batch' when used with --to-csv/--from-csv.",
+)
+@click.option(
+    "--to-csv",
+    is_flag=True,
+    hidden=True,
+    help="Generate a project .biotope.csv (use with -r).",
+)
+@click.option(
+    "--from-csv",
+    is_flag=True,
+    hidden=True,
+    help="Apply updates from project .biotope.csv (use with -r).",
+)
+@click.pass_context
+def annotate(
+    ctx: click.Context,
+    recursive: bool = False,
+    to_csv: bool = False,
+    from_csv: bool = False,
+) -> None:
+    """Create dataset metadata in Croissant format.
+
+    Tip: use 'biotope annotate batch --to-csv' to export or '--from-csv' to import.
+    The '-r' flag is a shorthand for these batch CSV operations.
+    """
+    # Handle short-hand alias only when no subcommand is provided
+    if ctx.invoked_subcommand is None:
+        # If user passed legacy flags without -r, guide them to new usage
+        if (to_csv or from_csv) and not recursive:
+            click.echo("❌ Direct --to-csv/--from-csv are deprecated. Use 'biotope annotate batch --to-csv' or 'biotope annotate batch --from-csv' (or prefix with -r).")
+            raise click.Abort
+
+        if recursive and (to_csv or from_csv):
+            biotope_root = find_biotope_root()
+            if not biotope_root:
+                click.echo("❌ Not in a biotope project. Run 'biotope init' first.")
+                raise click.Abort
+
+            if to_csv and from_csv:
+                click.echo("❌ Please specify only one of --to-csv or --from-csv")
+                raise click.Abort
+
+            if to_csv:
+                _generate_project_biotope_csv(biotope_root)
+                ctx.exit(0)
+
+            if from_csv:
+                console = Console()
+                csv_path = biotope_root / ".biotope.csv"
+                if not csv_path.exists():
+                    click.echo("❌ No .biotope.csv found at project root. Run 'biotope annotate batch --to-csv' first.")
+                    raise click.Abort
+                _process_csv_annotation(console, str(csv_path), None, biotope_root)
+                try:
+                    csv_path.unlink()
+                    click.echo("🗑️  Removed .biotope.csv after applying updates")
+                except Exception:
+                    click.echo("⚠️  Warning: Could not delete .biotope.csv; please remove it manually if desired")
+                ctx.exit(0)
+
+        # No subcommand and no alias flags → show help and signal usage error (exit code 2)
+        # Mimic Click's default behavior when a subcommand is required
+        click.echo(ctx.get_help())
+        # Use Click's fail to set exit code 2
+        ctx.fail("Missing command.")
 
 
 @annotate.command()
@@ -116,7 +182,7 @@ def annotate() -> None:
 )
 @click.option(
     "--date",
-    default=datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat(),
+    default=datetime.now(tz=timezone.utc).isoformat(),
     help="Date of creation (ISO format: YYYY-MM-DD).",
 )
 @click.option(
@@ -337,49 +403,70 @@ def load(jsonld, record_set, num_records):
         exit(1)
 
 
-@annotate.command()
+@annotate.command(help="Batch operations for CSV-based annotations. Export with --to-csv or import with --from-csv.")
+@click.option(
+    "--to-csv",
+    is_flag=True,
+    help="Export: write .biotope.csv at project root",
+)
 @click.option(
     "--from-csv",
-    type=click.Path(exists=True),
-    help="Path to CSV file containing batch annotation data",
+    "apply_from_csv",
+    is_flag=True,
+    help="Apply updates from a CSV (defaults to project .biotope.csv)",
 )
 @click.option(
     "--column-mapping",
     "-m",
     type=str,
-    help="JSON string mapping CSV column names to expected fields (e.g., '{\"data_file\": \"filepath\"}')",
+    help="JSON mapping CSV column names to expected fields (e.g., '{\"data_file\": \"filepath\"}')",
 )
 def batch(
-    from_csv: str | None = None,
-    column_mapping: str | None = None
+    to_csv: bool = False,
+    apply_from_csv: bool = False,
+    column_mapping: str | None = None,
 ) -> None:
-    """Batch annotate multiple files from a CSV file.
-    
-    This command updates the metadata for files that have already been added to the biotope project.
-    All files specified in the CSV must be already added/staged in the biotope project using 'biotope add'.
-    
-    The CSV should have columns for filepath, description, and other optional metadata.
-    The dataset name is automatically derived from the filepath.
-    Use --column-mapping to map your CSV columns to the expected metadata fields.
-    
-    Process:
-    1. Validates that all files in CSV are already staged in biotope
-    2. Finds the existing metadata files for those staged files
-    3. Updates the existing metadata with information from the CSV
-    
+    """Export or import annotations via CSV.
+
     Examples:
-        biotope annotate batch --from-csv batch_data.csv
-        biotope annotate batch --from-csv my_data.csv --column-mapping '{"data_file": "filepath"}'
+      biotope annotate batch --to-csv
+      biotope annotate batch --from-csv
     """
     console = Console()
 
-    # Require CSV file
-    if not from_csv:
-        console.print("❌ CSV file is required. Use --from-csv option for help.")
+    biotope_root = find_biotope_root()
+    if not biotope_root:
+        click.echo("❌ Not in a biotope project. Run 'biotope init' first.")
         raise click.Abort
 
-    # Handle CSV file processing
-    _process_csv_annotation(console, from_csv, column_mapping)
+    if to_csv and apply_from_csv:
+        console.print("❌ Please specify only one of --to-csv or --from-csv")
+        raise click.Abort
+
+    if not to_csv and not apply_from_csv:
+        console.print("❌ Specify one mode: --to-csv or --from-csv")
+        raise click.Abort
+
+    if to_csv:
+        _generate_project_biotope_csv(biotope_root)
+        return
+
+    resolved_csv_path: Path
+    resolved_csv_path = biotope_root / ".biotope.csv"
+
+    if not resolved_csv_path.exists():
+        console.print(f"❌ CSV file not found: {resolved_csv_path}")
+        raise click.Abort
+
+    _process_csv_annotation(console, str(resolved_csv_path), column_mapping, biotope_root)
+
+    # Delete project CSV only if we used the default location (mirrors -r behavior)
+    if resolved_csv_path.name == ".biotope.csv":
+        try:
+            resolved_csv_path.unlink()
+            click.echo("🗑️  Removed .biotope.csv after applying updates")
+        except Exception:
+            click.echo("⚠️  Warning: Could not delete .biotope.csv; please remove it manually if desired")
 
 
 @annotate.command()
@@ -664,7 +751,7 @@ def interactive(
 
     date = click.prompt(
         "Creation date (YYYY-MM-DD)",
-        default=metadata.get("dateCreated", datetime.date.today().isoformat()),
+        default=metadata.get("dateCreated", datetime.now(tz=timezone.utc).isoformat()),
     )
 
     # Section: Access Information
@@ -1128,7 +1215,7 @@ def _run_interactive_annotation(console: Console, file_path: Path, prefill_metad
     
     date = click.prompt(
         "Creation date (YYYY-MM-DD)",
-        default=metadata.get("dateCreated", datetime.date.today().isoformat()),
+        default=metadata.get("dateCreated", datetime.now(tz=timezone.utc).isoformat()),
     )
     
     # Section: Access Information
@@ -1315,6 +1402,7 @@ def _process_csv_annotation(
     # Define expected columns and their mappings
     expected_columns = {
         "filepath": "filepath",
+        "name": "name",
         "description": "description",
         "data_url": "url",
         "creator": "creator.name",
@@ -1327,6 +1415,7 @@ def _process_csv_annotation(
         "publication_date": "datePublished",
         "version": "version",
         "license": "license",
+        "license_url": "license",
         "citation": "citation"
     }
     
@@ -1346,11 +1435,14 @@ def _process_csv_annotation(
             raise click.Abort
             
         with open(csv_path, 'r', newline='', encoding='utf-8') as f:
-            # Try to detect the CSV dialect
+            # Try to detect the CSV dialect; fall back to standard comma CSV if detection fails
             sample = f.read(1024)
             f.seek(0)
             sniffer = csv.Sniffer()
-            dialect = sniffer.sniff(sample)
+            try:
+                dialect = sniffer.sniff(sample)
+            except Exception:
+                dialect = csv.excel  # default to comma-delimited
             
             reader = csv.DictReader(f, dialect=dialect)
             rows = list(reader)
@@ -1430,6 +1522,8 @@ def _process_csv_annotation(
         
         # Process each validated file
         successful_annotations = 0
+        updated_count = 0
+        unchanged_count = 0
         for i, (filepath, row) in enumerate(csv_files_to_process, 1):
             console.print(f"\n[bold green]Processing entry {i}/{len(csv_files_to_process)}[/]")
             
@@ -1440,7 +1534,11 @@ def _process_csv_annotation(
                 metadata = _build_metadata_from_csv_row(row, expected_columns, biotope_root, filepath)
                 
                 # Update existing annotation
-                _create_annotation_from_metadata(console, filepath, metadata, biotope_root, csv_file)
+                result = _create_annotation_from_metadata(console, filepath, metadata, biotope_root, csv_file)
+                if result is True:
+                    updated_count += 1
+                elif result is False:
+                    unchanged_count += 1
                 successful_annotations += 1
                 
             except Exception as e:
@@ -1448,6 +1546,8 @@ def _process_csv_annotation(
                 continue
         
         console.print(f"\n✅ Successfully processed {successful_annotations}/{len(csv_files_to_process)} annotations")
+        console.print(f"✅ Updated: {updated_count}")
+        console.print(f"ℹ️  Unchanged: {unchanged_count}")
         
         if successful_annotations > 0:
             # Stage the changes in Git
@@ -1458,7 +1558,7 @@ def _process_csv_annotation(
                     cwd=biotope_root,
                     check=True
                 )
-                console.print("✅ Staged all changes in Git")
+                console.print("\n✅ Staged all changes in Git")
             except subprocess.CalledProcessError as e:
                 console.print(f"⚠️  Warning: Could not stage changes in Git: {e}")
         
@@ -1470,19 +1570,108 @@ def _process_csv_annotation(
         raise click.Abort
 
 
+def _generate_project_biotope_csv(biotope_root: Path) -> None:
+    datasets_dir = biotope_root / ".biotope" / "datasets"
+    csv_path = biotope_root / ".biotope.csv"
+
+    if not datasets_dir.exists():
+        click.echo("❌ No datasets found (.biotope/datasets missing). Add files first with 'biotope add'.")
+        raise click.Abort
+
+    # Column order
+    csv_columns = [
+        "filepath",
+        "name",
+        "description",
+        "data_url",
+        "creator",
+        "creator_email",
+        "project_name",
+        "date_created",
+        "access_restrictions",
+        "encoding_format",
+        "legal_obligations",
+        "collaboration_partner",
+        "publication_date",
+        "version",
+        "license",
+        "citation",
+    ]
+
+    # Simple 1:1 mapping for top-level keys
+    CSV_MAP = {
+        "data_url": "url",
+        "project_name": "cr:projectName",
+        "date_created": "dateCreated",
+        "access_restrictions": "cr:accessRestrictions",
+        "encoding_format": "encodingFormat",
+        "legal_obligations": "cr:legalObligations",
+        "collaboration_partner": "cr:collaborationPartner",
+        "publication_date": "datePublished",
+        "version": "version",
+    }
+
+    rows = []
+
+    for metadata_file in datasets_dir.rglob("*.jsonld"):
+        try:
+            metadata = json.loads(metadata_file.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+
+        # filepath: prefer distribution[0].contentUrl, else derive from path
+        data_rel_path = ""
+        dist = metadata.get("distribution") or []
+        if isinstance(dist, list) and dist and isinstance(dist[0], dict):
+            data_rel_path = str(dist[0].get("contentUrl") or "")
+        if not data_rel_path:
+            try:
+                data_rel_path = str(metadata_file.relative_to(datasets_dir).with_suffix(""))
+            except Exception:
+                continue
+
+        row = {c: "" for c in csv_columns}
+        row["filepath"] = data_rel_path
+
+        # name/description with simple fallbacks
+        row["name"] = metadata.get("name", Path(data_rel_path).stem)
+        row["description"] = metadata.get("description", f"Dataset for {Path(data_rel_path).name}")
+
+        # creator object (if present)
+        creator = metadata.get("creator") or {}
+        if isinstance(creator, dict):
+            row["creator"] = str(creator.get("name", ""))
+            row["creator_email"] = str(creator.get("email", ""))
+
+        # license with alias fallback
+        row["license"] = str(metadata.get("license") or metadata.get("license_url") or "")
+
+        # fill the rest from the flat map
+        for col, key in CSV_MAP.items():
+            row[col] = row[col] or str(metadata.get(key, "") or "")
+
+        rows.append(row)
+
+    if not rows:
+        click.echo("ℹ️  No metadata files found to export.")
+        return
+
+    try:
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=csv_columns)
+            writer.writeheader()
+            writer.writerows(rows)
+        click.echo(f"📝 Generated annotation CSV: {csv_path}")
+        click.echo("💡 Edit this file, then run 'biotope annotate batch --from-csv' to apply updates")
+    except Exception as e:
+        click.echo(f"⚠️  Warning: Could not generate .biotope.csv: {e}")
+
 def _build_metadata_from_csv_row(row: dict, expected_columns: dict, biotope_root: Path, filepath: str) -> dict:
     """Build metadata dictionary from CSV row."""
     metadata = {}
     
     # Generate default name from filepath if name is not provided
     default_name = Path(filepath).stem
-    
-    # Load project metadata for defaults
-    try:
-        from biotope.utils import load_project_metadata
-        project_metadata = load_project_metadata(biotope_root)
-    except:
-        project_metadata = {}
     
     # Map CSV columns to metadata fields
     for csv_col, metadata_field in expected_columns.items():
@@ -1506,33 +1695,24 @@ def _build_metadata_from_csv_row(row: dict, expected_columns: dict, biotope_root
     # Use default name if name not provided
     if "name" not in metadata or not metadata["name"]:
         metadata["name"] = default_name
-    
-    # Apply defaults from project metadata for missing fields
-    for key, value in project_metadata.items():
-        if key not in metadata:
-            metadata[key] = value
-    
-    # Set required defaults if still missing
-    if "dateCreated" not in metadata:
-        metadata["dateCreated"] = datetime.date.today().isoformat()
-    
-    if "creator" not in metadata:
-        metadata["creator"] = {
-            "@type": "Person",
-            "name": getpass.getuser()
-        }
-    
+
     return metadata
 
 
-def _create_annotation_from_metadata(console: Console, filepath: str, metadata: dict, biotope_root: Path, csv_file_path: str | None = None) -> None:
+def _create_annotation_from_metadata(
+    console: Console,
+    filepath: str,
+    metadata: dict,
+    biotope_root: Path,
+    csv_file_path: str | None = None
+) -> bool | None:
     """Update existing metadata file for a staged file."""
     # Find the existing metadata file for this staged file
     existing_metadata_file = _find_existing_metadata_file(filepath, biotope_root, csv_file_path)
     
     if not existing_metadata_file:
         console.print(f"❌ No existing metadata file found for '{filepath}'. File must be staged first with 'biotope add'.")
-        return
+        return None
     
     # Load existing metadata
     try:
@@ -1540,7 +1720,7 @@ def _create_annotation_from_metadata(console: Console, filepath: str, metadata: 
             existing_metadata = json.load(f)
     except (json.JSONDecodeError, IOError) as e:
         console.print(f"❌ Error reading existing metadata file {existing_metadata_file}: {e}")
-        return
+        return None
     
     # Update existing metadata with new values from CSV, preserving distribution and other existing data
     updated_metadata = existing_metadata.copy()
@@ -1561,11 +1741,17 @@ def _create_annotation_from_metadata(console: Console, filepath: str, metadata: 
             if distribution.get("@type") == "sc:FileObject":
                 distribution["encodingFormat"] = metadata["encodingFormat"]
     
+    # If nothing changed, skip writing
+    if updated_metadata == existing_metadata:
+        console.print(f"ℹ️ Metadata unchanged")
+        return False
+    
     # Write updated metadata back to the same file
     with open(existing_metadata_file, "w") as f:
         json.dump(updated_metadata, f, indent=2)
     
-    console.print(f"✅ Updated: {existing_metadata_file.relative_to(biotope_root)}")
+    console.print(f"✅ Metadata updated")
+    return True
 
 
 def _find_existing_metadata_file(filepath: str, biotope_root: Path, csv_file_path: str | None = None) -> Path | None:
@@ -1628,6 +1814,3 @@ def get_staged_files(biotope_root: Path) -> list:
         pass
     
     return staged_files
-
-
-

--- a/biotope/commands/init.py
+++ b/biotope/commands/init.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import click
 import yaml
 from rich.console import Console
+import subprocess
 
 from biotope.utils import is_git_repo
 
@@ -18,7 +19,15 @@ from biotope.utils import is_git_repo
     default=".",
     help="Directory to initialize biotope project in",
 )
-def init(dir: Path) -> None:  # noqa: A002
+@click.option(
+    "--non-interactive",
+    "-n",
+    is_flag=True,
+    default=False,
+    help="Run initialization without interactive prompts (fail if required inputs missing).",
+)
+
+def init(dir: Path, non_interactive: bool) -> None:  # noqa: A002
     """
     Initialize a new biotope with interactive configuration in the specified directory.
     """
@@ -66,17 +75,38 @@ def init(dir: Path) -> None:  # noqa: A002
     click.echo("Establishing biotope! Let's set up your project.\n")
 
     # Project name
-    project_name = click.prompt(
-        "What's your project name?",
-        type=str,
-        default=dir.absolute().name,
-    )
+    if non_interactive:
+        # derive username from git if available, otherwise fallback to system user
+        try:
+            git_name = (
+                subprocess.run(
+                    ["git", "config", "user.name"], stdout=subprocess.PIPE, check=True
+                )
+                .stdout.decode()
+                .strip()
+            )
+        except Exception:
+            import getpass
+
+            git_name = getpass.getuser()
+
+        project_name = f"{git_name}_project"
+        click.echo(f"Initializing biotope automatically with project name: {project_name}")
+    else:
+        project_name = click.prompt(
+            "What's your project name?",
+            type=str,
+            default=dir.absolute().name,
+        )
 
     # Knowledge sources
     knowledge_sources = []
-    use_knowledge_graph = click.confirm(
-        "Would you like to install a knowledge graph now?", default=False
-    )
+    if non_interactive:
+        use_knowledge_graph = False
+    else:
+        use_knowledge_graph = click.confirm(
+            "Would you like to install a knowledge graph now?", default=False
+        )
     if use_knowledge_graph:
         while True:
             source = click.prompt(
@@ -104,9 +134,12 @@ def init(dir: Path) -> None:  # noqa: A002
         )
 
     # LLM integration
-    use_llm = click.confirm(
-        "\nWould you like to set up LLM integration?", default=False
-    )
+    if non_interactive:
+        use_llm = False
+    else:
+        use_llm = click.confirm(
+            "\nWould you like to set up LLM integration?", default=False
+        )
     if use_llm:
         llm_provider = click.prompt(
             "Which LLM provider would you like to use?",
@@ -123,18 +156,22 @@ def init(dir: Path) -> None:  # noqa: A002
                 hide_input=True,
             )
 
-    # Project-level metadata collection for pre-filling annotations
     console = Console()
-    console.print("\n[bold blue]Project Metadata Setup[/]")
-    console.print(
-        "The following information will be used to pre-fill metadata forms when creating dataset annotations."
-    )
-    console.print("You can skip any fields and provide them later during annotation.")
+    if not non_interactive:
+    # Project-level metadata collection for pre-filling annotations
+        console.print("\n[bold blue]Project Metadata Setup[/]")
+        console.print(
+            "The following information will be used to pre-fill metadata forms when creating dataset annotations."
+        )
+        console.print("You can skip any fields and provide them later during annotation.")
 
-    collect_project_metadata = click.confirm(
-        "\nWould you like to set up project-level metadata now? This will be used to pre-fill metadata later.",
-        default=True,
-    )
+    if non_interactive:
+        collect_project_metadata = False
+    else:
+        collect_project_metadata = click.confirm(
+            "\nWould you like to set up project-level metadata now? This will be used to pre-fill metadata later.",
+            default=True,
+        )
 
     project_metadata = {}
     if collect_project_metadata:

--- a/biotope/commands/status.py
+++ b/biotope/commands/status.py
@@ -240,13 +240,13 @@ def _get_git_status(biotope_root: Path, biotope_only: bool) -> Dict[str, List]:
                 continue
             
             # Parse Git status line (e.g., "M  .biotope/datasets/file.jsonld")
-            status = line[:2].strip()
+            status = line[:2]
             file_path = line[3:]
             
             if status == "??":
                 untracked.append(file_path)
-            elif status in ["A", "M", "D", "R"]:
-                staged.append((status, file_path))
+            elif status in ["A ", "M ", "D ", "R "]:
+                staged.append((status.strip(), file_path))
             elif status in [" M", " D", " R"]:
                 modified.append((status.strip(), file_path))
         

--- a/biotope/utils.py
+++ b/biotope/utils.py
@@ -14,7 +14,8 @@ def find_biotope_root() -> Optional[Path]:
     Find the biotope project root directory.
 
     Searches upward from the current working directory to find a directory
-    containing a .biotope/ subdirectory.
+    containing a .biotope/ subdirectory. Enforces that .git and .biotope 
+    must be in the same directory.
 
     Returns:
         Path to the biotope project root, or None if not found
@@ -22,6 +23,8 @@ def find_biotope_root() -> Optional[Path]:
     current = Path.cwd()
     while current != current.parent:
         if (current / ".biotope").exists():
+            if not (current / ".git").exists():
+                return None
             return current
         current = current.parent
     return None

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -38,6 +38,9 @@ def biotope_project(tmp_path):
     biotope_dir = tmp_path / ".biotope"
     biotope_dir.mkdir()
     
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    
     # Create datasets directory
     datasets_dir = biotope_dir / "datasets"
     datasets_dir.mkdir()

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -211,7 +211,7 @@ def test_add_file_absolute_path(git_repo, sample_file):
     with open(metadata_file) as f:
         metadata = json.load(f)
     
-    assert metadata["name"] == target_file.stem
+    assert metadata["name"] == str(target_file.relative_to(git_repo))
     assert metadata["distribution"][0]["name"] == target_file.name
     assert metadata["distribution"][0]["contentUrl"] == str(target_file.relative_to(git_repo))
     assert "sha256" in metadata["distribution"][0]
@@ -251,7 +251,7 @@ def test_add_file_relative_path(git_repo):
         with open(metadata_file) as f:
             metadata = json.load(f)
         
-        assert metadata["name"] == relative_path.stem
+        assert metadata["name"] == str(target_file.relative_to(git_repo))
         assert metadata["distribution"][0]["name"] == relative_path.name
         assert metadata["distribution"][0]["contentUrl"] == str(relative_path)
         assert "sha256" in metadata["distribution"][0]

--- a/tests/commands/test_add.py
+++ b/tests/commands/test_add.py
@@ -388,7 +388,7 @@ def test_add_command_relative_path(
         os.chdir(original_cwd)
 
 
-@mock.patch("biotope.utils.find_biotope_root")
+@mock.patch("biotope.commands.add.find_biotope_root")
 def test_add_command_no_biotope_project(mock_find_root, runner, tmp_path):
     """Test add command when not in a biotope project."""
     mock_find_root.return_value = None

--- a/tests/commands/test_annotate.py
+++ b/tests/commands/test_annotate.py
@@ -764,6 +764,100 @@ def test_batch_from_csv_noop_when_unedited(runner, tmp_path):
     finally:
         os.chdir(prev_cwd)
 
+
+def test_batch_from_csv_updates_when_edited(runner, tmp_path):
+    """batch --from-csv should update metadata when CSV values change."""
+    project_root = tmp_path
+    prev_cwd = os.getcwd()
+    try:
+        os.chdir(project_root)
+        metadata_path = _write_simple_project_with_metadata(project_root)
+
+        # Generate CSV
+        to_csv_result = runner.invoke(annotate, ["batch", "--to-csv"])
+        assert to_csv_result.exit_code == 0
+        csv_path = project_root / ".biotope.csv"
+        assert csv_path.exists()
+
+        # Edit CSV: change description and add encoding_format
+        rows = []
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames
+            rows = list(reader)
+        assert rows
+        rows[0]["description"] = "Updated description from CSV"
+        rows[0]["encoding_format"] = "text/csv"
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+        # Apply from CSV
+        from_csv_result = runner.invoke(annotate, ["batch", "--from-csv"])
+        assert from_csv_result.exit_code == 0
+        assert "Updated: 1" in from_csv_result.output
+
+        # Verify metadata actually changed and distribution encodingFormat updated
+        with open(metadata_path, encoding="utf-8") as f:
+            updated = json.load(f)
+        assert updated["description"] == "Updated description from CSV"
+        # encodingFormat should be applied at top-level or on file objects per logic
+        if "encodingFormat" in updated:
+            assert updated["encodingFormat"] == "text/csv"
+        if "distribution" in updated:
+            for d in updated["distribution"]:
+                if d.get("@type") == "sc:FileObject":
+                    assert d.get("encodingFormat") == "text/csv"
+    finally:
+        os.chdir(prev_cwd)
+
+
+def test_batch_from_csv_updates_creator_name(runner, tmp_path):
+    """Changing the creator column in CSV should update creator.name in JSON-LD."""
+    project_root = tmp_path
+    prev_cwd = os.getcwd()
+    try:
+        os.chdir(project_root)
+        metadata_path = _write_simple_project_with_metadata(project_root)
+        with open(metadata_path, encoding="utf-8") as f:
+            original = json.load(f)
+        # Ensure creator exists initially (or add minimal one)
+        if "creator" not in original:
+            original["creator"] = {"@type": "Person", "name": "Old Name"}
+            with open(metadata_path, "w", encoding="utf-8") as f:
+                json.dump(original, f, indent=2)
+
+        # Generate CSV
+        to_csv_result = runner.invoke(annotate, ["batch", "--to-csv"])
+        assert to_csv_result.exit_code == 0
+        csv_path = project_root / ".biotope.csv"
+        assert csv_path.exists()
+
+        # Edit CSV: change creator
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames
+            rows = list(reader)
+        assert rows
+        rows[0]["creator"] = "New Creator Name"
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+
+        # Apply from CSV
+        from_csv_result = runner.invoke(annotate, ["batch", "--from-csv"])
+        assert from_csv_result.exit_code == 0
+        assert "Updated:" in from_csv_result.output
+
+        # Verify creator updated
+        with open(metadata_path, encoding="utf-8") as f:
+            updated = json.load(f)
+        assert updated.get("creator", {}).get("name") == "New Creator Name"
+    finally:
+        os.chdir(prev_cwd)
+
 @pytest.mark.integration
 def test_real_validation_complex_metadata_cli(runner, tmp_path):
     """Test that complex metadata is actually valid using the real mlcroissant CLI."""

--- a/tests/commands/test_annotate.py
+++ b/tests/commands/test_annotate.py
@@ -3,6 +3,7 @@
 import datetime
 import getpass
 import json
+import csv
 import os
 import subprocess
 from pathlib import Path
@@ -42,7 +43,7 @@ def sample_metadata_file(tmp_path):
             "@type": "Person",
             "name": "researcher@university.edu",
         },
-        "dateCreated": "2023-01-15",
+        "dateCreated": "2025-08-27T13:37:12.651208+00:00",
         "cr:accessRestrictions": "Restricted to research use only",
         "encodingFormat": "CSV",
         "cr:legalObligations": "Data usage agreement required",
@@ -167,7 +168,7 @@ def test_create_command_with_required_fields(runner, tmp_path):
 def test_create_command_with_defaults(runner, tmp_path):
     """Test creating a new metadata file with default values for some fields."""
     output_path = tmp_path / "output.json"
-    today = datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat()
+    today_date = datetime.datetime.now(tz=datetime.timezone.utc).date().isoformat()
     username = getpass.getuser()
 
     # Run the create command with minimal required fields
@@ -197,7 +198,12 @@ def test_create_command_with_defaults(runner, tmp_path):
     assert metadata["description"] == ""  # Default empty string
     assert metadata["url"] == "https://example.org/proteomics"  # Changed from dataSource
     assert metadata["creator"]["name"] == username  # Changed from contactPerson
-    assert metadata["dateCreated"] == today  # Changed from creationDate
+    # Expect an ISO 8601 datetime with timezone; date portion should be today
+    date_created_str = metadata["dateCreated"]
+    assert "T" in date_created_str  # ensure datetime-like format
+    dt = datetime.datetime.fromisoformat(date_created_str.replace("Z", "+00:00"))
+    assert dt.tzinfo is not None and dt.utcoffset() == datetime.timedelta(0)
+    assert dt.date().isoformat() == today_date
     assert metadata["cr:accessRestrictions"] == "Public"  # Added cr: prefix
 
     # Optional fields should not be present
@@ -670,6 +676,93 @@ def test_real_validation_with_mlcroissant_cli(runner, tmp_path):
         f"Validation failed with error: {validation_error if 'validation_error' in locals() else 'unknown error'}"
     )
 
+
+def _write_simple_project_with_metadata(project_root: Path) -> Path:
+    """Helper: create a minimal biotope project with one metadata file."""
+    os.makedirs(project_root / ".git", exist_ok=True)
+    datasets_dir = project_root / ".biotope" / "datasets" / "data"
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    metadata_path = datasets_dir / "file1.jsonld"
+    metadata = {
+        "@context": {"@vocab": "https://schema.org/"},
+        "@type": "Dataset",
+        "name": "data/file1.csv",
+        "description": "Dataset for file1.csv",
+        "license": "https://creativecommons.org/licenses/by/4.0/",
+        "citation": "Please cite this dataset as: Example (2025)",
+        "cr:projectName": "example-project",
+        "distribution": [
+            {
+                "@type": "sc:FileObject",
+                "@id": "file_abc12345",
+                "name": "file1.csv",
+                "contentUrl": "data/file1.csv",
+            }
+        ],
+    }
+    with open(metadata_path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f, indent=2)
+
+    return metadata_path
+
+
+def test_batch_to_csv_generates_project_csv(runner, tmp_path):
+    """batch --to-csv creates .biotope.csv with rows from existing metadata."""
+    project_root = tmp_path
+    prev_cwd = os.getcwd()
+    try:
+        os.chdir(project_root)
+        _write_simple_project_with_metadata(project_root)
+
+        result = runner.invoke(annotate, ["batch", "--to-csv"])
+        assert result.exit_code == 0
+
+        csv_path = project_root / ".biotope.csv"
+        assert csv_path.exists()
+
+        with open(csv_path, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+
+        assert len(rows) == 1
+        row = rows[0]
+        # Required columns present and populated
+        assert row["filepath"] == "data/file1.csv"
+        assert row["description"] == "Dataset for file1.csv"
+        # Optional columns exist in header
+        assert "name" in row and "data_url" in row
+    finally:
+        os.chdir(prev_cwd)
+
+
+def test_batch_from_csv_noop_when_unedited(runner, tmp_path):
+    """batch --from-csv should not modify metadata when CSV is unedited."""
+    project_root = tmp_path
+    prev_cwd = os.getcwd()
+    try:
+        os.chdir(project_root)
+        metadata_path = _write_simple_project_with_metadata(project_root)
+        before = metadata_path.read_text(encoding="utf-8")
+
+        # Generate CSV
+        to_csv_result = runner.invoke(annotate, ["batch", "--to-csv"])
+        assert to_csv_result.exit_code == 0
+        csv_path = project_root / ".biotope.csv"
+        assert csv_path.exists()
+
+        # Import from CSV without changes
+        from_csv_result = runner.invoke(annotate, ["batch", "--from-csv"])
+        assert from_csv_result.exit_code == 0
+        # The command cleans up the CSV file after applying
+        assert not csv_path.exists()
+
+        after = metadata_path.read_text(encoding="utf-8")
+        assert before == after  # No change expected
+        # Summary should report unchanged = 1
+        assert "Unchanged: 1" in from_csv_result.output
+    finally:
+        os.chdir(prev_cwd)
 
 @pytest.mark.integration
 def test_real_validation_complex_metadata_cli(runner, tmp_path):

--- a/tests/commands/test_annotate_staged.py
+++ b/tests/commands/test_annotate_staged.py
@@ -24,6 +24,9 @@ def biotope_project(tmp_path):
     biotope_dir = tmp_path / ".biotope"
     biotope_dir.mkdir()
     
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    
     # Create datasets directory
     datasets_dir = biotope_dir / "datasets"
     datasets_dir.mkdir()

--- a/tests/commands/test_mv.py
+++ b/tests/commands/test_mv.py
@@ -42,6 +42,9 @@ def biotope_project(tmp_path):
     biotope_dir = tmp_path / ".biotope"
     biotope_dir.mkdir()
     
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    
     # Create datasets directory
     datasets_dir = biotope_dir / "datasets"
     datasets_dir.mkdir()
@@ -56,6 +59,9 @@ def biotope_project_with_file(tmp_path):
     biotope_dir = tmp_path / ".biotope"
     datasets_dir = biotope_dir / "datasets"
     datasets_dir.mkdir(parents=True)
+    
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
     
     # Create test data file
     data_dir = tmp_path / "data" / "raw"
@@ -987,6 +993,9 @@ def biotope_project_with_directory(tmp_path):
     biotope_dir = tmp_path / ".biotope"
     datasets_dir = biotope_dir / "datasets"
     datasets_dir.mkdir(parents=True)
+    
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
     
     # Create test data directory with multiple files
     data_dir = tmp_path / "experiment_data"

--- a/tests/commands/test_status_validation.py
+++ b/tests/commands/test_status_validation.py
@@ -24,6 +24,9 @@ def biotope_project(tmp_path):
     biotope_dir = tmp_path / ".biotope"
     biotope_dir.mkdir()
     
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    
     # Create config directory
     config_dir = biotope_dir / "config"
     config_dir.mkdir()

--- a/tests/unit/test_git_commands.py
+++ b/tests/unit/test_git_commands.py
@@ -211,11 +211,13 @@ class TestGitIntegration:
 
     def test_find_biotope_root(self, tmp_path):
         """Test finding biotope root."""
-        from biotope.commands.commit import find_biotope_root
+        from biotope.utils import find_biotope_root
         import os
+        from unittest.mock import patch
         
         # Should not find biotope root in empty directory
-        assert find_biotope_root() is None
+        with patch("biotope.utils.Path.cwd", return_value=tmp_path):
+            assert find_biotope_root() is None
         
         # Create .biotope and .git directories (both required)
         biotope_dir = tmp_path / ".biotope"

--- a/tests/unit/test_git_commands.py
+++ b/tests/unit/test_git_commands.py
@@ -217,9 +217,11 @@ class TestGitIntegration:
         # Should not find biotope root in empty directory
         assert find_biotope_root() is None
         
-        # Create .biotope directory
+        # Create .biotope and .git directories (both required)
         biotope_dir = tmp_path / ".biotope"
         biotope_dir.mkdir()
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
         
         # Change to tmp_path and find root
         original_cwd = os.getcwd()

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -357,3 +357,29 @@ def test_init_metadata():
             assert "last_modified" in project_info
             assert isinstance(project_info["builds"], list)
             assert isinstance(project_info["knowledge_sources"], list)
+
+
+def test_init_non_interactive():
+    """Test initialization with --non-interactive flag uses git user.name and skips prompts."""
+    import subprocess
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        # Initialize a git repo and set a user.name so non-interactive can derive project name
+        subprocess.run(["git", "init"], check=True, capture_output=True)
+        subprocess.run(["git", "config", "user.name", "ci-user"], check=True, capture_output=True)
+
+        result = runner.invoke(
+            init,
+            ["--non-interactive"],
+            obj={"version": "0.1.0"},
+        )
+
+        assert result.exit_code == 0
+        # Should announce automatic initialization with derived project name
+        assert "Initializing biotope automatically with project name" in result.output
+
+        # Check that config was created with the derived project name
+        with open("config/biotope.yaml") as f:
+            config = yaml.safe_load(f)
+            assert config["project"]["name"] == "ci-user_project"

--- a/tests/unit/test_init_git.py
+++ b/tests/unit/test_init_git.py
@@ -77,6 +77,9 @@ class TestInitWithGit:
 
     def test_init_existing_git_repo(self, runner, tmp_path):
         """Test init in existing Git repository (env-independent)."""
+        
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
 
         def mock_subprocess_run(args, **kwargs):
             from subprocess import CalledProcessError

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,10 +1,7 @@
 """Unit tests for biotope utilities."""
 
 import yaml
-from pathlib import Path
 from unittest.mock import patch
-
-import pytest
 
 from biotope.utils import find_biotope_root, is_git_repo, load_project_metadata
 
@@ -15,9 +12,10 @@ def test_find_biotope_root(tmp_path):
     project_dir = tmp_path / "project"
     project_dir.mkdir()
     
-    # Create .biotope directory
     biotope_dir = project_dir / ".biotope"
     biotope_dir.mkdir()
+    git_dir = project_dir / ".git"
+    git_dir.mkdir()
     
     # Test from project root
     with patch("biotope.utils.Path.cwd", return_value=project_dir):
@@ -37,6 +35,16 @@ def test_find_biotope_root(tmp_path):
     outside_dir.mkdir()
     
     with patch("biotope.utils.Path.cwd", return_value=outside_dir):
+        result = find_biotope_root()
+        assert result is None
+    
+    # Test .biotope without .git (should fail)
+    invalid_project_dir = tmp_path / "invalid_project"
+    invalid_project_dir.mkdir()
+    invalid_biotope_dir = invalid_project_dir / ".biotope"
+    invalid_biotope_dir.mkdir()
+    
+    with patch("biotope.utils.Path.cwd", return_value=invalid_project_dir):
         result = find_biotope_root()
         assert result is None
 


### PR DESCRIPTION
The goal is to be able to use `biotope annotate batch --from-csv <csv path>` to annotate multiple files instead of going through these files one by one with the `biotope annotate interactive`.

One thing that can be done is do generate a `.biotope.csv` file when using `biotope add` with a flag, which has some default annotations already (as well as all other suggested annotations). Users can modify this csv file and then annotate their files.

Updated checklist (August, 4th)
- [x] Add `biotope status --detailed` option. (fix #7)
- [x] Insure `.git` and `.biotope` are in the same dir during initialization. (fix #9)
- [ ] Add `biotope annotate interactive -r <directory or pattern>`
- [x] `biotope annotate --to-csv` -> creates a `.biotope.csv` file, which you have your annotations created from Croissant. It would be easier for the users to update this annotation file.
- [x] Add `biotope annotate batch --from-csv`, synonymous to `biotope annotate -r --from-csv` -> uses `.biotope.csv` to update the Croissant metadata (or `biotope annotate export` or sth)
- [x] When doing `biotope add <sth>` we should have the minimum needed metadata with prefilled values.
- [x] Added `--non-interactive` flag for the `biotope init` (fix #15)
- [x] Write tests for all the new features.