### PR TITLE
Adding biotope initialization in the output directory when downloading a dataset without initialized biotope

### DIFF
--- a/biotope/commands/get.py
+++ b/biotope/commands/get.py
@@ -10,6 +10,7 @@ import requests
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from biotope.commands.add import _add_file
+from biotope.commands.init import init
 from biotope.utils import find_biotope_root, is_git_repo, stage_git_changes
 
 
@@ -107,9 +108,17 @@ def get(url: str, output_dir: str, no_add: bool) -> None:
     """
     # Find biotope project root
     biotope_root = find_biotope_root()
+    
     if not biotope_root:
-        click.echo("❌ Not in a biotope project. Run 'biotope init' first.")
-        raise click.Abort
+        # Initialize biotope project in the output directory
+        output_path = Path(output_dir)
+        output_path.mkdir(parents=True, exist_ok=True)
+
+        init(dir=output_path)
+
+        biotope_root = find_biotope_root(current=output_path)
+        click.echo(f"Initialized new biotope project in {biotope_root}")
+        
 
     # Check if we're in a Git repository
     if not is_git_repo(biotope_root):

--- a/biotope/commands/init.py
+++ b/biotope/commands/init.py
@@ -18,6 +18,10 @@ from biotope.utils import is_git_repo
     default=".",
     help="Directory to initialize biotope project in",
 )
+def init_command(dir: Path) -> None:  # noqa: A002
+    init(dir)
+    
+
 def init(dir: Path) -> None:  # noqa: A002
     """
     Initialize a new biotope with interactive configuration in the specified directory.

--- a/biotope/utils.py
+++ b/biotope/utils.py
@@ -9,17 +9,18 @@ from typing import Optional
 import click
 
 
-def find_biotope_root() -> Optional[Path]:
+def find_biotope_root(current: Path | None = None) -> Optional[Path]:
     """
     Find the biotope project root directory.
 
-    Searches upward from the current working directory to find a directory
-    containing a .biotope/ subdirectory.
+    Searches upward from the current working directory or the provided 
+    'current' dir to find a directory containing a .biotope/ subdirectory.
 
     Returns:
         Path to the biotope project root, or None if not found
     """
-    current = Path.cwd()
+    if current is None:
+        current = Path.cwd()
     while current != current.parent:
         if (current / ".biotope").exists():
             return current


### PR DESCRIPTION
…nit functionality from init command for reusing it in other commands; added init in case no biotope project is found during get

- [ ] fix #(issue number)
- [ ] description of feature/fix
- [ ] tests added/passed
- [ ] add an entry to the [changelog](../CHANGELOG.md)
