### PR TITLE
Make "biotope get" a universal ingress verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ uv pip install -e ".[dev]"         # editable, with test deps (for biotope itsel
 uvx biotope init my-kg --purpose "What approved drugs target genes in T2D?" --no-prompt
 cd my-kg && uv sync
 
-# 2. Bring in data — biotope get downloads + tracks; biotope add stages a
-#    local file/folder and runs croissant-baker over it.
-uv run biotope get https://example.org/opentargets.parquet --output-dir data/ot --no-add
-uv run biotope add data/ot --license CC-BY-4.0 --creator "Open Targets"
+# 2. Bring in data — `biotope get` is the universal ingress verb: copy or
+#    download a local file, directory, or URL into the project (or `--crawl` a
+#    site) and bake its manifest in one shot, recording where it came from.
+#    `biotope add` registers data already in the tree (e.g. derived artifacts).
+uv run biotope get https://example.org/opentargets.parquet --into data/ot --license CC-BY-4.0
 
 # 3. Inspect the pipeline state at any time.
 uv run biotope queue        # raw / processed / mapped, with provenance footer

--- a/biotope/commands/add.py
+++ b/biotope/commands/add.py
@@ -21,6 +21,7 @@ from biotope.metadata import (
     normalize_metadata_shape,
     parse_key_value_pairs,
     resolve_target,
+    set_source,
     set_status,
 )
 from biotope.utils import (
@@ -53,7 +54,7 @@ from biotope.utils import (
     "status_override",
     type=click.Choice(["raw", "processed"]),
     default=None,
-    help="Override pipeline state. Default: 'processed' if baker produced a " "complete record set, 'raw' otherwise.",
+    help="Override pipeline state. Default: 'processed' if baker produced a complete record set, 'raw' otherwise.",
 )
 @click.option(
     "--derived-from",
@@ -224,6 +225,7 @@ def _add_file(
     _enrich_with_baker(metadata, abs_file)
     _apply_dataset_metadata(metadata, defaults, overrides, biotope_root)
     _apply_pipeline_state(metadata, overrides)
+    _apply_source_provenance(metadata, overrides)
 
     target = resolve_target(abs_file, biotope_root)
     target.metadata_path.parent.mkdir(parents=True, exist_ok=True)
@@ -448,6 +450,7 @@ def _bake_directory(
     _dedupe_file_objects_covered_by_filesets(metadata_dict, abs_dir, biotope_root)
     _append_uncovered_file_objects(metadata_dict, abs_dir, biotope_root)
     _apply_pipeline_state(metadata_dict, overrides)
+    _apply_source_provenance(metadata_dict, overrides)
 
     target.metadata_path.parent.mkdir(parents=True, exist_ok=True)
     with open(target.metadata_path, "w", encoding="utf-8") as handle:
@@ -615,7 +618,19 @@ def _default_overrides() -> dict[str, Any]:
         "rai_fields": {},
         "status_override": None,
         "derived_from": [],
+        "source": None,
+        "fetched_at": None,
     }
+
+
+def _apply_source_provenance(metadata: dict[str, Any], overrides: dict[str, Any]) -> None:
+    """Stamp external ingress provenance (``dct:source`` + fetch timestamp).
+
+    No-op for plain ``biotope add`` (data already in the tree, no external
+    origin). ``biotope get`` populates ``source``/``fetched_at`` to record the
+    URL or path the data was brought in from.
+    """
+    set_source(metadata, overrides.get("source"), overrides.get("fetched_at"))
 
 
 def _apply_pipeline_state(metadata: dict[str, Any], overrides: dict[str, Any]) -> None:
@@ -677,7 +692,9 @@ def _resolve_dataset_ref(ref: str, biotope_root: Path) -> str:
         return str(rel.with_suffix("") if rel.suffix else rel)
 
     # If it's a data dir we just baked, the canonical id is the dir rel path.
-    dir_manifest = (datasets_dir / rel).with_suffix(".jsonld")
+    # Append ``.jsonld`` rather than ``with_suffix`` so a dotted directory name
+    # (e.g. a scraped ``data/example.com``) isn't clobbered to ``example.jsonld``.
+    dir_manifest = datasets_dir / f"{rel}.jsonld"
     if dir_manifest.is_file():
         return str(rel)
 

--- a/biotope/commands/get.py
+++ b/biotope/commands/get.py
@@ -1,16 +1,61 @@
-"""Command for downloading files and integrating with biotope workflow."""
+"""``biotope get`` — the universal ingress verb.
+
+Brings external data into the project tree and bakes its Croissant manifest in
+one shot, recording where the data came from (``dct:source`` + a fetch
+timestamp). Dispatches on the shape of ``source``:
+
+* **local file** — ``biotope get /scratch/data/foo.csv`` (copy + bake)
+* **local directory** — ``biotope get /scratch/data/source_pull`` (recursive copy + bake)
+* **http(s) file/page** — ``biotope get https://example.com/data.csv`` (download + bake)
+* **website scrape** — ``biotope get --crawl --depth 2 https://example.com/topic/``
+
+Unsupported transports (``s3://``, ``scp://``, …) are reported as not-yet-supported
+and tracked as follow-up issues. ``biotope add`` remains the verb for data that
+already lives inside the project tree.
+"""
 
 from __future__ import annotations
 
+import json
+import shutil
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 import click
 import requests
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from biotope.commands.add import _add_file
-from biotope.utils import find_biotope_root, is_git_repo, stage_git_changes
+from biotope.commands.add import (
+    _add_file,
+    _apply_dataset_metadata,
+    _apply_pipeline_state,
+    _bake_directory,
+    _default_overrides,
+    _generate_biotope_scaffold_from_baked,
+    _resolve_dataset_ref,
+)
+from biotope.metadata import (
+    SOURCE_KEY,
+    make_file_object,
+    merge_metadata,
+    parse_key_value_pairs,
+    resolve_target,
+    set_source,
+)
+from biotope.scrape import ScrapeError, crawl
+from biotope.utils import (
+    find_biotope_root,
+    is_git_repo,
+    load_project_metadata,
+    stage_git_changes,
+)
+
+
+# Transports recognised but deliberately deferred to follow-up issues.
+_DEFERRED_SCHEMES = frozenset({"s3", "gs", "gcs", "scp", "sftp", "ftp", "ssh", "azure", "abfs", "abfss"})
 
 
 def download_file(url: str, output_dir: Path) -> Path | None:
@@ -28,8 +73,13 @@ def download_file(url: str, output_dir: Path) -> Path | None:
 
         if not filename:
             filename = Path(urlparse(url).path).name
-            if not filename or filename == "":
-                filename = "downloaded_file"
+
+        # The filename is server-controlled (Content-Disposition or URL path):
+        # reduce it to a bare basename so a malicious ``../../etc/foo`` or
+        # ``/abs/path`` can't escape ``output_dir`` and write arbitrary files.
+        filename = Path(filename).name
+        if not filename or set(filename) <= {"."}:
+            filename = "downloaded_file"
 
         output_path = output_dir / filename
 
@@ -54,38 +104,114 @@ def download_file(url: str, output_dir: Path) -> Path | None:
         return None
 
 
-def _call_biotope_add(file_path: Path, biotope_root: Path) -> bool:
-    """Add downloaded file to biotope project."""
+def _classify_source(source: str) -> str:
+    """Classify a source string as ``"http"``, ``"local"``, or ``"unsupported"``."""
+    scheme = urlparse(source).scheme.lower()
+    if scheme in ("http", "https"):
+        return "http"
+    if scheme in _DEFERRED_SCHEMES:
+        return "unsupported"
+    # Everything else — no scheme, ``file://``, Windows drive letters — is a path.
+    return "local"
+
+
+def _normalize_local_source(source: str) -> Path:
+    """Resolve a local source string (``file://`` URL or plain path) to a Path."""
+    parsed = urlparse(source)
+    if parsed.scheme == "file":
+        return Path(url2pathname(parsed.path))
+    return Path(source).expanduser()
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True if ``path`` is ``root`` or lives underneath it."""
     try:
-        # Create datasets directory
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _display(path: Path, biotope_root: Path) -> str:
+    """Render ``path`` relative to the project root when possible, else absolute."""
+    try:
+        return str(path.relative_to(biotope_root))
+    except ValueError:
+        return str(path)
+
+
+def _build_overrides(
+    biotope_root: Path,
+    *,
+    status: str | None,
+    name: str | None,
+    description: str | None,
+    license_value: str | None,
+    creator: str | None,
+    creator_email: str | None,
+    url: str | None,
+    citation: str | None,
+    version: str | None,
+    keywords: tuple[str, ...],
+    access_restrictions: str | None,
+    legal_obligations: str | None,
+    collaboration_partner: str | None,
+    rai_pairs: tuple[str, ...],
+    derived_from: tuple[str, ...],
+    fetched_at: str,
+) -> dict[str, Any]:
+    """Assemble the add-style overrides dict from ``get``'s CLI flags."""
+    try:
+        rai_fields = parse_key_value_pairs(rai_pairs, "--rai")
+    except ValueError as exc:
+        raise click.BadParameter(str(exc)) from exc
+
+    try:
+        resolved_provenance = [_resolve_dataset_ref(ref, biotope_root) for ref in derived_from]
+    except ValueError as exc:
+        raise click.BadParameter(str(exc)) from exc
+
+    return {
+        "name": name,
+        "description": description,
+        "license": license_value,
+        "creator": creator,
+        "creator_email": creator_email,
+        "url": url,
+        "citation": citation,
+        "version": version,
+        "keywords": list(keywords),
+        "access_restrictions": access_restrictions,
+        "legal_obligations": legal_obligations,
+        "collaboration_partner": collaboration_partner,
+        "rai_fields": rai_fields,
+        "status_override": status,
+        "derived_from": resolved_provenance,
+        "source": None,
+        "fetched_at": fetched_at,
+    }
+
+
+def _call_biotope_add(
+    file_path: Path,
+    biotope_root: Path,
+    overrides: dict[str, Any] | None = None,
+) -> bool:
+    """Bake a single-file manifest for ``file_path`` and stage it in Git."""
+    overrides = overrides if overrides is not None else _default_overrides()
+    try:
         datasets_dir = biotope_root / ".biotope" / "datasets"
         datasets_dir.mkdir(parents=True, exist_ok=True)
 
-        # Add the file using the same logic as the add command
         success = _add_file(
             file_path,
             biotope_root,
             datasets_dir,
             force=False,
-            overrides={
-                "name": None,
-                "description": None,
-                "license": None,
-                "creator": None,
-                "creator_email": None,
-                "url": None,
-                "citation": None,
-                "version": None,
-                "keywords": [],
-                "access_restrictions": None,
-                "legal_obligations": None,
-                "collaboration_partner": None,
-                "rai_fields": {},
-            },
+            overrides=overrides,
         )
 
         if success:
-            # Stage changes in Git
             stage_git_changes(biotope_root)
 
         return success
@@ -96,78 +222,455 @@ def _call_biotope_add(file_path: Path, biotope_root: Path) -> bool:
     except PermissionError:
         click.echo(f"❌ Permission denied accessing: {file_path}", err=True)
         return False
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         click.echo(f"❌ Failed to add file to biotope project: {e}", err=True)
         return False
 
 
+def _next_steps_file() -> None:
+    """Echo the standard post-ingest next steps for a single tracked file."""
+    click.echo("\n💡 Next steps:")
+    click.echo("  1. Run 'biotope status' to see staged files")
+    click.echo("  2. Run 'biotope annotate --staged' to create metadata")
+    click.echo("  3. Run 'biotope commit -m \"message\"' to save changes")
+
+
+def _ensure_project(ctx: click.Context, into: str) -> tuple[Path, Path | None]:
+    """Find the biotope root, scaffolding one in ``into`` if outside a project.
+
+    Returns ``(biotope_root, autoinit_dir)`` where ``autoinit_dir`` is non-None
+    only when a project was just scaffolded (so the caller knows to land data at
+    the new root rather than under ``into`` again).
+    """
+    biotope_root = find_biotope_root()
+    if biotope_root:
+        return biotope_root, None
+
+    from biotope.commands.init import init as init_cmd
+
+    output_path = Path(into)
+    output_path.mkdir(parents=True, exist_ok=True)
+    click.echo(f"📦 No biotope project found; initialising one at {output_path}")
+    ctx.invoke(init_cmd, name=".", dir=output_path, no_prompt=True)
+    biotope_root = find_biotope_root(start=output_path)
+    if not biotope_root:
+        click.echo("❌ Failed to initialise biotope project.")
+        raise click.Abort
+    return biotope_root, output_path
+
+
+def _ingest_local_file(
+    src: Path,
+    dest_dir: Path,
+    biotope_root: Path,
+    overrides: dict[str, Any],
+    no_add: bool,
+) -> None:
+    """Copy a local file into the project and bake its manifest."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_file = dest_dir / src.name
+    if dest_file.resolve() == src:
+        click.echo(f"❌ Source and destination are the same file: {src}")
+        raise click.Abort
+
+    click.echo(f"📥 Copying file: {src} → {_display(dest_file, biotope_root)}")
+    shutil.copy2(src, dest_file)
+    click.echo(f"✅ Copied: {_display(dest_file, biotope_root)}")
+
+    if no_add:
+        click.echo("\n💡 File copied. To add to biotope project:")
+        click.echo(f"  biotope add {_display(dest_file, biotope_root)}")
+        return
+
+    click.echo("📁 Adding file to biotope project...")
+    if _call_biotope_add(dest_file, biotope_root, overrides):
+        click.echo("✅ File added to biotope project")
+        _next_steps_file()
+    else:
+        click.echo("⚠️  File copied but not added to biotope project")
+        click.echo(f"   You can manually add it with: biotope add {_display(dest_file, biotope_root)}")
+
+
+def _ingest_local_dir(
+    src: Path,
+    dest_dir: Path,
+    biotope_root: Path,
+    overrides: dict[str, Any],
+    no_add: bool,
+) -> None:
+    """Recursively copy a local directory into the project and bake one manifest."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_path = dest_dir / src.name
+
+    click.echo(f"📥 Copying directory: {src} → {_display(dest_path, biotope_root)}")
+    # Skip symlinks rather than dereference them: following links from an
+    # untrusted source could copy external secrets into the project (and a
+    # link to a parent dir would loop). The project stays self-contained.
+    skipped_links: list[str] = []
+
+    def _ignore_symlinks(directory: str, names: list[str]) -> list[str]:
+        ignored = [name for name in names if (Path(directory) / name).is_symlink()]
+        skipped_links.extend(str(Path(directory) / name) for name in ignored)
+        return ignored
+
+    shutil.copytree(src, dest_path, dirs_exist_ok=True, ignore=_ignore_symlinks)
+    if skipped_links:
+        click.echo(f"⚠️  Skipped {len(skipped_links)} symlink(s) for self-containment (copied real files only).")
+    n_files = sum(1 for p in dest_path.rglob("*") if p.is_file())
+    click.echo(f"✅ Copied {n_files} file(s) into {_display(dest_path, biotope_root)}")
+
+    if no_add:
+        click.echo("\n💡 Directory copied. To add to biotope project:")
+        click.echo(f"  biotope add {_display(dest_path, biotope_root)}")
+        return
+
+    click.echo("📁 Baking directory manifest...")
+    baked = _bake_directory(dest_path, biotope_root, overrides)
+    if baked is None:
+        click.echo("⚠️  Directory copied but no manifest was baked.")
+        click.echo(f"   You can retry with: biotope add {_display(dest_path, biotope_root)}")
+        return
+
+    metadata_dict, n_source_files = baked
+    stage_git_changes(biotope_root)
+    _generate_biotope_scaffold_from_baked(dest_path.resolve(), metadata_dict, biotope_root)
+
+    target = resolve_target(dest_path.resolve(), biotope_root)
+    n_record_sets = len(metadata_dict.get("recordSet", []))
+    click.echo(
+        f"✨ Generated {_display(target.metadata_path, biotope_root)} "
+        f"({n_source_files} source file(s), {n_record_sets} record set(s))"
+    )
+    click.echo("\n💡 Next steps:")
+    click.echo(f"  • Review {_display(dest_path / '.biotope.yaml', biotope_root)}")
+    click.echo(f"    Then: biotope annotate apply {_display(dest_path, biotope_root)}")
+    click.echo("  • Map data into the knowledge graph: biotope map")
+    click.echo('  • Finally: biotope commit -m "message"')
+
+
+def _handle_local(
+    source: str,
+    dest_dir: Path,
+    biotope_root: Path,
+    overrides: dict[str, Any],
+    no_add: bool,
+) -> None:
+    """Validate and dispatch a local file/directory ingress."""
+    src = _normalize_local_source(source)
+    if not src.exists():
+        click.echo(f"❌ Source not found: {source}")
+        raise click.Abort
+
+    src_abs = src.resolve()
+    if _is_within(src_abs, biotope_root.resolve()):
+        rel = src_abs.relative_to(biotope_root.resolve())
+        click.echo(f"❌ '{source}' is already inside the project ({rel}).")
+        click.echo(f"   Use 'biotope add {rel}' to register data already in the tree.")
+        raise click.Abort
+
+    overrides = {**overrides, "source": str(src_abs)}
+    if src_abs.is_dir():
+        _ingest_local_dir(src_abs, dest_dir, biotope_root, overrides, no_add)
+    else:
+        _ingest_local_file(src_abs, dest_dir, biotope_root, overrides, no_add)
+
+
+def _handle_http(
+    source: str,
+    dest_dir: Path,
+    biotope_root: Path,
+    overrides: dict[str, Any],
+    no_add: bool,
+) -> None:
+    """Download a single http(s) file/page into the project and bake its manifest."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    click.echo(f"📥 Downloading file from: {source}")
+    downloaded_file = download_file(source, dest_dir)
+    if not downloaded_file:
+        click.echo("❌ Failed to download file")
+        raise click.Abort
+    click.echo(f"✅ Downloaded: {downloaded_file}")
+
+    if no_add:
+        click.echo("\n💡 File downloaded. To add to biotope project:")
+        click.echo(f"  biotope add {downloaded_file}")
+        return
+
+    overrides = {**overrides, "source": source}
+    click.echo("📁 Adding file to biotope project...")
+    if _call_biotope_add(downloaded_file, biotope_root, overrides):
+        click.echo("✅ File added to biotope project")
+        _next_steps_file()
+    else:
+        click.echo("⚠️  File downloaded but not added to biotope project")
+        click.echo(f"   You can manually add it with: biotope add {downloaded_file}")
+
+
+def _bake_scrape_manifest(
+    result,
+    dataset_dir: Path,
+    biotope_root: Path,
+    seed_url: str,
+    overrides: dict[str, Any],
+):
+    """Write one manifest covering all scraped pages, with per-page provenance."""
+    defaults = load_project_metadata(biotope_root)
+    fetched_at = overrides.get("fetched_at") or datetime.now(tz=timezone.utc).isoformat()
+    # Resolve both sides so ``relative_to`` is robust to symlinked roots
+    # (e.g. macOS /tmp → /private/tmp).
+    root = biotope_root.resolve()
+    dataset_dir = dataset_dir.resolve()
+    rel = dataset_dir.relative_to(root)
+
+    metadata = merge_metadata(
+        {
+            "name": overrides.get("name") or str(rel),
+            "description": (
+                overrides.get("description") or defaults.get("description") or f"Pages scraped from {seed_url}"
+            ),
+            "distribution": [],
+            "dateCreated": fetched_at,
+        }
+    )
+
+    for page in result.pages:
+        file_object = make_file_object((dataset_dir / page.relpath).resolve(), root)
+        # Per-page provenance: record where THIS page came from, inline on the
+        # FileObject, so the manifest can answer it without the dataset-level field.
+        file_object[SOURCE_KEY] = page.url
+        metadata["distribution"].append(file_object)
+
+    _apply_dataset_metadata(metadata, defaults, overrides, root)
+    _apply_pipeline_state(metadata, overrides)
+    set_source(metadata, seed_url, fetched_at)
+
+    target = resolve_target(dataset_dir, root)
+    target.metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(target.metadata_path, "w", encoding="utf-8") as handle:
+        json.dump(metadata, handle, indent=2)
+    return metadata, target
+
+
+def _handle_scrape(
+    source: str,
+    dest_dir: Path,
+    biotope_root: Path,
+    overrides: dict[str, Any],
+    no_add: bool,
+    *,
+    depth: int,
+    max_pages: int,
+    rate: float,
+    respect_robots: bool,
+) -> None:
+    """Bounded-crawl an http(s) site and bake one manifest over the saved pages."""
+    host = urlparse(source).netloc
+    safe_host = host.replace(":", "_") or "site"
+    dataset_dir = dest_dir / safe_host
+
+    robots_note = "" if respect_robots else ", ignoring robots.txt"
+    click.echo(f"🕸️  Crawling {source} (depth {depth}, ≤{max_pages} pages, {rate} req/s{robots_note})")
+    try:
+        result = crawl(
+            source,
+            dataset_dir,
+            depth=depth,
+            max_pages=max_pages,
+            rate=rate,
+            respect_robots=respect_robots,
+            echo=click.echo,
+        )
+    except ScrapeError as exc:
+        click.echo(f"❌ {exc}")
+        raise click.Abort from exc
+
+    if not result.pages:
+        click.echo("❌ No pages saved — nothing matched, or all candidates were blocked or failed.")
+        if result.skipped:
+            click.echo(f"   ({len(result.skipped)} URL(s) skipped; first: {result.skipped[0][1]})")
+        raise click.Abort
+
+    click.echo(f"✅ Saved {len(result.pages)} page(s) under {_display(dataset_dir, biotope_root)}")
+    if result.skipped:
+        click.echo(f"   ({len(result.skipped)} URL(s) skipped)")
+
+    if no_add:
+        click.echo("\n💡 Pages saved. To add to biotope project:")
+        click.echo(f"  biotope add {_display(dataset_dir, biotope_root)}")
+        return
+
+    overrides = {**overrides, "source": source}
+    _metadata, target = _bake_scrape_manifest(result, dataset_dir, biotope_root, source, overrides)
+    stage_git_changes(biotope_root)
+    click.echo(f"✨ Baked manifest: {_display(target.metadata_path, biotope_root)}")
+    click.echo("\n💡 Next steps:")
+    click.echo(f"  1. Review {_display(target.metadata_path, biotope_root)} (one FileObject per page)")
+    click.echo("  2. Process the raw HTML into a derived artifact, then 'biotope add ... --derived-from'")
+    click.echo("  3. Run 'biotope commit -m \"message\"' to save changes")
+
+
 @click.command()
-@click.argument("url")
+@click.argument("source")
 @click.option(
+    "--into",
     "--output-dir",
     "-o",
+    "into",
     type=click.Path(file_okay=False),
     default="data",
-    help="Directory to save downloaded files",
+    help="Project subdirectory the data lands in (default: data). The source's basename is preserved underneath it.",
 )
 @click.option(
     "--no-add",
     is_flag=True,
-    help="Download file without adding to biotope project",
+    help="Bring the data in without baking a manifest / tracking it.",
+)
+@click.option(
+    "--status",
+    "status",
+    type=click.Choice(["raw", "processed"]),
+    default=None,
+    help="Override pipeline state. Default: classify like 'biotope add' "
+    "(structured data → processed, documents/HTML → raw).",
+)
+@click.option(
+    "--crawl", "crawl_mode", is_flag=True, help="Crawl a website instead of fetching one file (http(s) only)."
+)
+@click.option(
+    "--depth",
+    type=click.IntRange(min=0),
+    default=1,
+    show_default=True,
+    help="Crawl: link-following hops from the seed.",
+)
+@click.option(
+    "--max-pages", type=click.IntRange(min=1), default=50, show_default=True, help="Crawl: cap on pages saved."
+)
+@click.option(
+    "--rate",
+    type=click.FloatRange(min=0.0, min_open=True),
+    default=1.0,
+    show_default=True,
+    help="Crawl: requests per second.",
+)
+@click.option("--ignore-robots", is_flag=True, help="Crawl: do not consult robots.txt.")
+@click.option("--name", help="Dataset name override")
+@click.option("--description", help="Dataset description override")
+@click.option("--license", "license_value", help="Dataset license")
+@click.option("--creator", help="Dataset creator name")
+@click.option("--creator-email", help="Dataset creator email")
+@click.option("--url", help="Dataset homepage URL")
+@click.option("--citation", help="Dataset citation text")
+@click.option("--version", help="Dataset version")
+@click.option("--keyword", "keywords", multiple=True, help="Dataset keyword (repeatable)")
+@click.option("--access-restrictions", help="Dataset access restrictions")
+@click.option("--legal-obligations", help="Dataset legal obligations")
+@click.option("--collaboration-partner", help="Dataset collaboration partner")
+@click.option("--rai", "rai_pairs", multiple=True, help="Croissant RAI field as KEY=VALUE")
+@click.option(
+    "--derived-from",
+    "derived_from",
+    multiple=True,
+    help="Record this dataset as derived from another (repeatable). Pass a "
+    "dataset reference — data path, manifest path, or dataset name.",
 )
 @click.pass_context
-def get(ctx: click.Context, url: str, output_dir: str, no_add: bool) -> None:
-    """Download a file and integrate with biotope workflow.
+def get(
+    ctx: click.Context,
+    source: str,
+    into: str,
+    no_add: bool,
+    status: str | None,
+    crawl_mode: bool,
+    depth: int,
+    max_pages: int,
+    rate: float,
+    ignore_robots: bool,
+    name: str | None,
+    description: str | None,
+    license_value: str | None,
+    creator: str | None,
+    creator_email: str | None,
+    url: str | None,
+    citation: str | None,
+    version: str | None,
+    keywords: tuple[str, ...],
+    access_restrictions: str | None,
+    legal_obligations: str | None,
+    collaboration_partner: str | None,
+    rai_pairs: tuple[str, ...],
+    derived_from: tuple[str, ...],
+) -> None:
+    """Bring data into the project from a path, URL, or website, and track it.
 
-    If run outside a biotope project, scaffolds one in ``output_dir`` first so
-    the download has a home. This mirrors the behaviour proposed in PR #11.
+    SOURCE may be a local file or directory, an http(s) URL, or (with --crawl)
+    a website to crawl. The data is copied/downloaded into the project under
+    --into, its Croissant manifest is baked, and its origin is recorded
+    (dct:source + fetch timestamp). If run outside a biotope project, one is
+    scaffolded in --into first.
     """
-    output_path = Path(output_dir)
+    source_type = _classify_source(source)
+    if source_type == "unsupported":
+        scheme = urlparse(source).scheme
+        click.echo(f"❌ Unsupported source '{scheme}://…'. Transports like s3://, gs://, and scp:// are deferred")
+        click.echo("   to follow-up issues (see #22). Supported: local paths, directories, and http(s) URLs.")
+        raise click.Abort
 
-    biotope_root = find_biotope_root()
-    if not biotope_root:
-        # No surrounding project — scaffold one in-place at output_dir so the
-        # download can be tracked. Uses init's non-interactive path.
-        from biotope.commands.init import init as init_cmd
+    if crawl_mode and source_type != "http":
+        click.echo("❌ --crawl requires an http(s) URL.")
+        raise click.Abort
 
-        output_path.mkdir(parents=True, exist_ok=True)
-        click.echo(f"📦 No biotope project found; initialising one at {output_path}")
-        ctx.invoke(init_cmd, name=".", dir=output_path, no_prompt=True)
-        biotope_root = find_biotope_root(start=output_path)
-        if not biotope_root:
-            click.echo("❌ Failed to initialise biotope project.")
-            raise click.Abort
+    biotope_root, autoinit_dir = _ensure_project(ctx, into)
 
-    # Check if we're in a Git repository
     if not is_git_repo(biotope_root):
         click.echo("❌ Not in a Git repository. Initialize Git first with 'git init'.")
         raise click.Abort
 
-    # Create output directory if it doesn't exist
-    output_path.mkdir(parents=True, exist_ok=True)
+    fetched_at = datetime.now(tz=timezone.utc).isoformat()
+    overrides = _build_overrides(
+        biotope_root,
+        status=status,
+        name=name,
+        description=description,
+        license_value=license_value,
+        creator=creator,
+        creator_email=creator_email,
+        url=url,
+        citation=citation,
+        version=version,
+        keywords=keywords,
+        access_restrictions=access_restrictions,
+        legal_obligations=legal_obligations,
+        collaboration_partner=collaboration_partner,
+        rai_pairs=rai_pairs,
+        derived_from=derived_from,
+        fetched_at=fetched_at,
+    )
 
-    # Download the file
-    click.echo(f"📥 Downloading file from: {url}")
-    downloaded_file = download_file(url, output_path)
+    # When a project was just scaffolded, it lives at ``into`` — land data at the
+    # new root rather than nesting ``into`` inside itself again.
+    dest_dir = biotope_root if autoinit_dir is not None else biotope_root / Path(into)
 
-    if not downloaded_file:
-        click.echo("❌ Failed to download file")
-        raise click.Abort
+    # ``--into`` must stay inside the project tree. An absolute value or a
+    # ``..`` escape would otherwise dump data outside the project (and crash the
+    # bake step), since ``biotope_root / Path(abs)`` discards the root.
+    if not _is_within(dest_dir.resolve(), biotope_root.resolve()):
+        raise click.BadParameter("--into must be a subdirectory inside the project root.", param_hint="--into")
 
-    click.echo(f"✅ Downloaded: {downloaded_file}")
-
-    # Add to biotope project unless --no-add flag is used
-    if not no_add:
-        click.echo("📁 Adding file to biotope project...")
-        if _call_biotope_add(downloaded_file, biotope_root):
-            click.echo("✅ File added to biotope project")
-            click.echo("\n💡 Next steps:")
-            click.echo("  1. Run 'biotope status' to see staged files")
-            click.echo("  2. Run 'biotope annotate --staged' to create metadata")
-            click.echo("  3. Run 'biotope commit -m \"message\"' to save changes")
-        else:
-            click.echo("⚠️  File downloaded but not added to biotope project")
-            click.echo(f"   You can manually add it with: biotope add {downloaded_file}")
+    if source_type == "local":
+        _handle_local(source, dest_dir, biotope_root, overrides, no_add)
+    elif crawl_mode:
+        _handle_scrape(
+            source,
+            dest_dir,
+            biotope_root,
+            overrides,
+            no_add,
+            depth=depth,
+            max_pages=max_pages,
+            rate=rate,
+            respect_robots=not ignore_robots,
+        )
     else:
-        click.echo("\n💡 File downloaded. To add to biotope project:")
-        click.echo(f"  biotope add {downloaded_file}")
+        _handle_http(source, dest_dir, biotope_root, overrides, no_add)

--- a/biotope/metadata.py
+++ b/biotope/metadata.py
@@ -117,7 +117,7 @@ def ensure_no_legacy_file_objects(metadata: dict[str, Any]) -> None:
     for distribution in metadata.get("distribution", []) or []:
         if distribution.get("@type") == LEGACY_FILE_OBJECT_TYPE:
             raise ValueError(
-                "Legacy sc:FileObject is no longer supported. " "Please regenerate the metadata with `biotope add`."
+                "Legacy sc:FileObject is no longer supported. Please regenerate the metadata with `biotope add`."
             )
 
 
@@ -184,6 +184,42 @@ def add_derived_from(metadata: dict[str, Any], source_id: str) -> None:
         return
     refs = existing + [source_id]
     metadata["prov:wasDerivedFrom"] = [{"@id": ref} for ref in refs]
+
+
+# Ingress provenance keys. ``dct:source`` names the *external* origin a dataset
+# was brought in from (URL or filesystem path) — distinct from
+# ``prov:wasDerivedFrom``, which links to *other datasets inside the project*.
+SOURCE_KEY = "dct:source"
+FETCHED_AT_KEY = "biotope:fetchedAt"
+
+
+def set_source(metadata: dict[str, Any], source: str | None, fetched_at: str | None = None) -> None:
+    """Record where a dataset was ingested from.
+
+    ``source`` is the original external location — an ``http(s)`` URL or an
+    absolute filesystem path the data was copied/downloaded from. ``fetched_at``
+    is an ISO-8601 timestamp of when biotope retrieved it. Both are optional;
+    empty values are left unset so non-ingress manifests stay clean.
+    """
+    if source:
+        metadata[SOURCE_KEY] = source
+    if fetched_at:
+        metadata[FETCHED_AT_KEY] = fetched_at
+
+
+def get_source(metadata: dict[str, Any]) -> str | None:
+    """Return a manifest's ``dct:source`` origin, or ``None``.
+
+    Accepts both the bare-string form (``"https://…"``) and the node form
+    (``{"@id": "https://…"}``) that some Croissant tooling emits.
+    """
+    raw = metadata.get(SOURCE_KEY)
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        value = raw.get("@id")
+        return value if isinstance(value, str) else None
+    return None
 
 
 def update_manifest_status(manifest_path: Path, status: str) -> bool:
@@ -322,7 +358,10 @@ def resolve_target(path: Path, biotope_root: Path) -> DatasetTarget:
 
     if resolved.is_dir():
         rel_dir = resolved.relative_to(biotope_root)
-        metadata_path = (datasets_dir / rel_dir).with_suffix(".jsonld")
+        # Append ``.jsonld`` to the full path rather than ``.with_suffix`` —
+        # the latter would clobber a dot in the directory name (``example.com``
+        # → ``example.jsonld``), breaking the manifest↔data mirroring.
+        metadata_path = datasets_dir / f"{rel_dir}.jsonld"
         return DatasetTarget(
             input_path=resolved,
             metadata_path=metadata_path,
@@ -333,7 +372,7 @@ def resolve_target(path: Path, biotope_root: Path) -> DatasetTarget:
     if resolved.name == SCAFFOLD_FILENAME:
         dataset_dir = resolved.parent
         rel_dir = dataset_dir.relative_to(biotope_root)
-        metadata_path = (datasets_dir / rel_dir).with_suffix(".jsonld")
+        metadata_path = datasets_dir / f"{rel_dir}.jsonld"
         return DatasetTarget(
             input_path=resolved,
             metadata_path=metadata_path,

--- a/biotope/scrape.py
+++ b/biotope/scrape.py
@@ -1,0 +1,290 @@
+"""Bounded, polite static-HTML crawler backing ``biotope get --crawl``.
+
+v1 scope (issue #22): static HTML only, same-host breadth-first crawl to a
+bounded depth with a page cap, ``robots.txt`` respected by default, and a
+request rate limit. JS rendering, cross-host crawls, authentication, and
+non-HTML transports are deliberately out of scope.
+
+The module is intentionally free of any biotope-manifest knowledge: it fetches
+and saves pages, then returns what it saved so the caller can bake a manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections import deque
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Callable
+from urllib.parse import urldefrag, urljoin, urlparse
+from urllib.robotparser import RobotFileParser
+
+import requests
+
+
+DEFAULT_USER_AGENT = "biotope-get/1.0 (+https://github.com/biocypher/biotope)"
+HTML_CONTENT_TYPES = frozenset({"text/html", "application/xhtml+xml"})
+_NON_HTTP_LINK_PREFIXES = ("#", "mailto:", "javascript:", "tel:", "data:", "ftp:")
+
+
+class ScrapeError(RuntimeError):
+    """Raised when a crawl cannot proceed (bad seed, missing dependency, …)."""
+
+
+@dataclass(frozen=True)
+class ScrapedPage:
+    """One saved page: its source URL and the file path relative to the dest dir."""
+
+    url: str
+    relpath: Path
+
+
+@dataclass
+class ScrapeResult:
+    """Outcome of a crawl: what was saved, what was skipped, and the host."""
+
+    host: str
+    pages: list[ScrapedPage] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+
+
+def normalize_url(url: str) -> str:
+    """Drop the fragment from a URL; everything else is preserved verbatim."""
+    return urldefrag(url)[0]
+
+
+def url_to_relpath(url: str) -> str:
+    """Derive a filesystem-safe, ``.html``-suffixed relative path from a URL.
+
+    The host is *not* encoded here — the caller roots the crawl at a per-host
+    directory. Directory-style URLs map to ``index.html``; query strings are
+    disambiguated with a short digest so ``?page=1`` and ``?page=2`` don't
+    collide.
+    """
+    parsed = urlparse(url)
+    path = parsed.path or "/"
+
+    if path in ("", "/"):
+        rel = "index.html"
+    else:
+        rel = path.lstrip("/")
+        if path.endswith("/"):
+            rel = f"{rel}index.html"
+        elif PurePosixPath(rel).suffix.lower() not in (".html", ".htm"):
+            rel = f"{rel}.html"
+
+    if parsed.query:
+        digest = hashlib.sha1(parsed.query.encode("utf-8")).hexdigest()[:8]  # noqa: S324 - non-crypto disambiguator
+        p = PurePosixPath(rel)
+        rel = str(p.with_name(f"{p.stem}__{digest}{p.suffix}"))
+
+    return rel
+
+
+def _safe_join(dest_dir: Path, relpath: str) -> Path | None:
+    """Resolve ``relpath`` under ``dest_dir``, rejecting any escape (``..``)."""
+    dest_resolved = dest_dir.resolve()
+    candidate = (dest_resolved / relpath).resolve()
+    try:
+        candidate.relative_to(dest_resolved)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _require_beautifulsoup():
+    """Import BeautifulSoup lazily with a friendly error if it's missing."""
+    try:
+        from bs4 import BeautifulSoup
+    except ImportError as exc:  # pragma: no cover - exercised only without the dep
+        msg = "beautifulsoup4 is required for `biotope get --crawl`. Install it with `uv pip install beautifulsoup4`."
+        raise ScrapeError(msg) from exc
+    return BeautifulSoup
+
+
+def extract_links(html: str, base_url: str) -> list[str]:
+    """Return absolute, fragment-stripped ``http(s)`` links found in ``html``."""
+    beautiful_soup = _require_beautifulsoup()
+    soup = beautiful_soup(html, "html.parser")
+    links: list[str] = []
+    seen: set[str] = set()
+    for anchor in soup.find_all("a", href=True):
+        href = (anchor.get("href") or "").strip()
+        if not href or href.lower().startswith(_NON_HTTP_LINK_PREFIXES):
+            continue
+        absolute = normalize_url(urljoin(base_url, href))
+        if urlparse(absolute).scheme not in ("http", "https"):
+            continue
+        if absolute not in seen:
+            seen.add(absolute)
+            links.append(absolute)
+    return links
+
+
+def _load_robots(
+    seed_url: str,
+    session: requests.Session,
+    user_agent: str,
+    timeout: int,
+) -> RobotFileParser:
+    """Fetch and parse ``robots.txt`` for the seed's host.
+
+    Status handling follows common crawler convention:
+
+    * ``2xx`` — use the published rules.
+    * ``4xx`` (e.g. 404) — no policy exists, so allow all.
+    * ``5xx`` — the server is erroring; be conservative and treat as
+      disallow-all for this run rather than risk crawling against intent.
+    * network failure — the user explicitly chose to crawl this host and
+      ``robots.txt`` is simply unreachable, so fall back to allow-all.
+    """
+    parsed = urlparse(seed_url)
+    robots_url = f"{parsed.scheme}://{parsed.netloc}/robots.txt"
+    parser = RobotFileParser()
+    try:
+        response = session.get(robots_url, timeout=timeout, headers={"User-Agent": user_agent})
+    except requests.RequestException:
+        parser.parse([])
+        return parser
+    if response.status_code >= 500:
+        parser.parse(["User-agent: *", "Disallow: /"])
+    elif response.status_code >= 400:
+        parser.parse([])
+    else:
+        parser.parse(response.text.splitlines())
+    return parser
+
+
+def _content_type(response: requests.Response) -> str:
+    """Return the lower-cased MIME type (without parameters) of a response."""
+    return response.headers.get("Content-Type", "").split(";")[0].strip().lower()
+
+
+def crawl(
+    seed_url: str,
+    dest_dir: Path,
+    *,
+    depth: int = 1,
+    max_pages: int = 50,
+    rate: float = 1.0,
+    respect_robots: bool = True,
+    session: requests.Session | None = None,
+    user_agent: str = DEFAULT_USER_AGENT,
+    timeout: int = 30,
+    echo: Callable[[str], None] | None = None,
+) -> ScrapeResult:
+    """Crawl ``seed_url`` breadth-first, saving same-host HTML pages under ``dest_dir``.
+
+    Args:
+        seed_url: The ``http(s)`` page to start from.
+        dest_dir: Directory (created as needed) that saved pages are rooted at.
+        depth: Number of link-following hops from the seed (0 = seed only).
+        max_pages: Hard cap on pages saved (the per-host link cap for v1).
+        rate: Requests per second; consecutive fetches are throttled to ``1/rate``.
+        respect_robots: Honour the host's ``robots.txt`` (default True).
+        session: Optional pre-built requests session (injectable for tests).
+        user_agent: User-Agent sent on every request and matched against robots.
+        timeout: Per-request timeout in seconds.
+        echo: Optional progress sink (e.g. ``click.echo``); keeps this module
+            free of any CLI dependency.
+
+    Returns:
+        A :class:`ScrapeResult` listing saved pages and skipped URLs.
+
+    Raises:
+        ScrapeError: If the seed is not an ``http(s)`` URL.
+    """
+    parsed_seed = urlparse(seed_url)
+    if parsed_seed.scheme not in ("http", "https") or not parsed_seed.netloc:
+        msg = f"--crawl needs an http(s) URL; got {seed_url!r}"
+        raise ScrapeError(msg)
+
+    note = echo or (lambda _message: None)
+    session = session or requests.Session()
+    host = parsed_seed.netloc
+    interval = 1.0 / rate if rate and rate > 0 else 0.0
+
+    robots = _load_robots(seed_url, session, user_agent, timeout) if respect_robots else None
+    if robots is not None:
+        # Honour a host-requested Crawl-delay if it asks for a slower pace than --rate.
+        crawl_delay = robots.crawl_delay(user_agent)
+        if crawl_delay:
+            interval = max(interval, float(crawl_delay))
+
+    result = ScrapeResult(host=host)
+    visited: set[str] = set()
+    seen_relpaths: set[str] = set()
+    queue: deque[tuple[str, int]] = deque([(normalize_url(seed_url), 0)])
+    last_fetch = 0.0
+
+    while queue and len(result.pages) < max_pages:
+        url, current_depth = queue.popleft()
+        if url in visited:
+            continue
+        visited.add(url)
+
+        if urlparse(url).netloc != host:
+            result.skipped.append((url, "different host"))
+            continue
+        if robots is not None and not robots.can_fetch(user_agent, url):
+            result.skipped.append((url, "blocked by robots.txt"))
+            note(f"  ⏭️  robots.txt disallows {url}")
+            continue
+
+        if interval:
+            wait = last_fetch + interval - time.monotonic()
+            if wait > 0:
+                time.sleep(wait)
+        last_fetch = time.monotonic()
+
+        try:
+            response = session.get(url, timeout=timeout, headers={"User-Agent": user_agent})
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            result.skipped.append((url, f"fetch error: {exc}"))
+            note(f"  ⚠️  could not fetch {url}: {exc}")
+            continue
+
+        # Follow where redirects actually landed. A same-host URL that redirects
+        # off-host must not be saved under the seed host (it would break the
+        # same-host guarantee and mis-attribute provenance).
+        final_url = normalize_url(str(response.url))
+        if urlparse(final_url).netloc != host:
+            result.skipped.append((url, f"redirected off-host → {urlparse(final_url).netloc}"))
+            continue
+        visited.add(final_url)
+
+        content_type = _content_type(response)
+        if content_type and content_type not in HTML_CONTENT_TYPES:
+            result.skipped.append((final_url, f"non-HTML ({content_type})"))
+            continue
+
+        relpath = url_to_relpath(final_url)
+        if relpath in seen_relpaths:
+            # Two distinct URLs collapsed to the same file (e.g. /a and /a.html).
+            result.skipped.append((final_url, "duplicate path"))
+            continue
+        out_path = _safe_join(dest_dir, relpath)
+        if out_path is None:
+            result.skipped.append((final_url, "unsafe path"))
+            continue
+        seen_relpaths.add(relpath)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_bytes(response.content)
+        result.pages.append(ScrapedPage(url=final_url, relpath=out_path.relative_to(dest_dir.resolve())))
+        note(f"  📄 {final_url} → {out_path.relative_to(dest_dir.resolve())}")
+
+        if current_depth < depth:
+            try:
+                links = extract_links(response.text, final_url)
+            except ScrapeError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - a single bad page shouldn't abort the crawl
+                note(f"  ⚠️  could not parse links from {final_url}: {exc}")
+                links = []
+            for link in links:
+                if urlparse(link).netloc == host and link not in visited:
+                    queue.append((link, current_depth + 1))
+
+    return result

--- a/biotope/templates/AGENTS.md
+++ b/biotope/templates/AGENTS.md
@@ -15,11 +15,15 @@ exposed as a flag on a biotope command.
    stop sign — ask first.
 1. **Data lives inside the project.** A biotope project owns its data. The
    manifest at `.biotope/datasets/<rel>.jsonld` addresses `<project>/<rel>/`,
-   so files outside the project tree are not ingestible. Acceptable shapes:
-   copy into the project, or fetch via `biotope get <url>`. Symlinks that
-   point outside the project root are rejected — they break self-containment
-   (collaborators get a broken link) and let the target's contents drift
-   without changing the tracked manifest.
+   so files outside the project tree are not ingestible. To bring external
+   data in, use `biotope get <source>` — it copies/downloads files,
+   directories, or URLs into the project and bakes the manifest in one shot.
+   `biotope add` is then only for data already inside the tree (e.g. artifacts
+   you generated). Never hand-`cp` external data and never try to make
+   `biotope add` accept an outside path. Symlinks that point outside the
+   project root are rejected — they break self-containment (collaborators get a
+   broken link) and let the target's contents drift without changing the
+   tracked manifest.
 1. **`--clear-entities` / `--clear-relations` are destructive.** They erase
    the user's declared schema. Use only when the user has explicitly asked you
    to drop and rewrite intent — never as a tidy-up before re-encoding.
@@ -27,13 +31,15 @@ exposed as a flag on a biotope command.
 ## The canonical workflow
 
 ```
-biotope init  →  biotope add  →  biotope map  →  biotope build
+biotope init  →  biotope get  →  biotope map  →  biotope build
 ```
 
 - `init` creates the project skeleton and `.biotope/project.yaml`.
-- `add` brings each dataset under the project and writes its Croissant
-  metadata. **Do this before mapping**, so you can map against fields and
-  record sets that actually exist.
+- `get` brings each dataset *into* the project — from a local file, a
+  directory, or a URL — and writes its Croissant metadata, recording where the
+  data came from. Use `biotope add` instead to register data that is *already*
+  in the tree (e.g. an artifact you generated). **Do this before mapping**, so
+  you can map against fields and record sets that actually exist.
 - `map` does two things: captures intent (`--purpose`, `--entity`,
   `--relation`) into `project.yaml`, *and* authors per-dataset mappings under
   `mappings/` that resolve those entities/relations against real data.
@@ -108,40 +114,49 @@ the heuristic is wrong or a rare correction is needed.
 
 ## Bring data in
 
-**Step 1 — copy the source folder into the project.** Data must live under the
-project root before `biotope add` can address it (see Hard rule 2). If the
-user points at a directory outside the project, copy it in first; don't try
-to make `biotope add` accept external paths.
+**`biotope get <source>` is the one verb for ingress.** It dispatches on the
+shape of the source — copy/download into the project, bake the manifest, and
+record provenance (`dct:source` + a fetch timestamp) — in a single call. Never
+hand-`cp` external data and never try to make `biotope add` accept an outside
+path (see Hard rule 2).
 
 ```bash
-cp -r /elsewhere/source_pull data/source_pull
+biotope get /scratch/data/foo.csv            # local file  → data/foo.csv
+biotope get /scratch/data/source_pull        # local dir   → data/source_pull/
+biotope get https://example.com/data.csv     # URL         → data/data.csv
+biotope get --crawl --depth 2 https://example.com/topic/   # scrape → data/<host>/
 ```
 
-For files coming from URLs use `biotope get <url>` instead — it fetches them
-into the project tree directly.
-
-**Step 2 — `biotope add` on the whole copied folder, in one call.**
+`--into <subdir>` controls where the data lands (default `data`). For a
+directory, `get` runs croissant-baker over the whole copied tree and writes one
+manifest at `.biotope/datasets/data/source_pull.jsonld` plus a
+`<dir>/.biotope.yaml` for bulk human review:
 
 ```bash
-biotope add data/source_pull \
+biotope get /scratch/data/source_pull \
   --license "CC-BY-4.0" \
   --creator "Source Org" \
   --description "..."
-```
-
-`biotope add` runs croissant-baker on the directory (recursing automatically)
-and writes one manifest at `.biotope/datasets/data/source_pull.jsonld`
-covering the whole subtree. It also writes `<dir>/.biotope.yaml` for bulk
-human review; apply edits with:
-
-```bash
 biotope annotate apply data/source_pull
 biotope annotate apply data/source_pull --set creator="Source Org"
 ```
 
 Pass any metadata the baker *cannot* infer (license, creator, creator email,
 description, access restrictions, legal obligations, collaboration details,
-RAI metadata) as flags on the `add` call.
+RAI metadata) as flags on the `get` call — they are the same flags `biotope add` accepts.
+
+By default `get` classifies the new manifest exactly like `biotope add`
+(structured data → `processed`, documents/HTML/scrapes → `raw`); pass
+`--status raw|processed` to override. Scraped pages each record their own source
+URL on the `cr:FileObject`, so the manifest can say where every page came from.
+
+**`biotope add` is for data already in the tree** — typically a derived
+artifact you produced from a raw input. It takes the same metadata flags but
+does not move or fetch anything:
+
+```bash
+biotope add data/annual_report_tables.json --derived-from data/annual_report.pdf
+```
 
 ### Choosing what to `add`
 

--- a/docs/api-docs/get.md
+++ b/docs/api-docs/get.md
@@ -1,0 +1,102 @@
+# Biotope Get
+
+!!! warning "Draft stage"
+
+```
+Biotope is in draft stage. Functionality may be missing or incomplete.
+The API is subject to change.
+```
+
+`biotope get` is the universal **ingress** verb: it brings data into the project
+tree from outside, bakes the Croissant manifest, and records where the data came
+from — all in one shot. Use `biotope add` instead for data that already lives
+inside the project (e.g. agent-produced derived artifacts).
+
+`get` dispatches on the shape of the source:
+
+| Source            | Example                                              | Behaviour             |
+| ----------------- | ---------------------------------------------------- | --------------------- |
+| Local file        | `biotope get /scratch/data/foo.csv`                  | copy + bake           |
+| Local directory   | `biotope get /scratch/data/source_pull`              | recursive copy + bake |
+| http(s) file/page | `biotope get https://example.com/data.csv`           | download + bake       |
+| Website scrape    | `biotope get --crawl --depth 2 https://example.com/` | bounded crawl + bake  |
+
+Every manifest baked by `get` records its origin as `dct:source` (the URL or
+absolute path) plus a `biotope:fetchedAt` timestamp. For a scrape, each page's
+`cr:FileObject` also carries its own `dct:source`, so the manifest can answer
+"where did *this* page come from?".
+
+## Command Signature
+
+```bash
+biotope get [OPTIONS] SOURCE
+```
+
+## Options
+
+- `--into, --output-dir, -o`: project subdirectory the data lands in (default:
+  `data`). The source's basename is preserved underneath it.
+- `--no-add`: bring the data in without baking a manifest / tracking it.
+- `--status [raw|processed]`: override pipeline state. Default: classify like
+  `biotope add` (structured data → `processed`, documents/HTML → `raw`).
+- `--crawl`: crawl a website instead of fetching one file (http(s) only).
+- `--depth`: crawl link-following hops from the seed (default: 1).
+- `--max-pages`: crawl cap on pages saved (default: 50).
+- `--rate`: crawl requests per second (default: 1.0).
+- `--ignore-robots`: crawl without consulting `robots.txt`.
+- Dataset metadata overrides (same as `biotope add`): `--name`, `--description`,
+  `--license`, `--creator`, `--creator-email`, `--url`, `--citation`,
+  `--version`, `--keyword`, `--access-restrictions`, `--legal-obligations`,
+  `--collaboration-partner`, `--rai KEY=VALUE`, `--derived-from`.
+
+## Examples
+
+### Copy a local file from a scratch mount
+
+```bash
+biotope get /scratch/data/experiment.csv --license CC-BY-4.0
+# → data/experiment.csv  (+ .biotope/datasets/data/experiment.jsonld)
+```
+
+### Copy a local directory (one composite manifest)
+
+```bash
+biotope get /scratch/data/source_pull \
+  --creator "Source Org" \
+  --description "Whole pulled folder"
+# → data/source_pull/…  (+ one manifest covering the tree, + .biotope.yaml)
+```
+
+### Download a file from a URL
+
+```bash
+biotope get https://example.com/data.csv
+```
+
+### Scrape a website (bounded, polite)
+
+```bash
+biotope get --crawl --depth 2 --max-pages 30 https://example.com/topic/
+# → data/example.com/…  (one HTML file per page, one manifest)
+```
+
+The crawler stays on the seed's host, respects `robots.txt` (unless
+`--ignore-robots`), and rate-limits to `--rate` requests per second.
+
+## What It Does
+
+1. Classifies the source (local path, http(s) URL, or website to crawl).
+   Unsupported transports (`s3://`, `scp://`, …) are reported and deferred.
+1. If run outside a biotope project, scaffolds one in `--into` first.
+1. Copies / downloads / crawls the data into the project under `--into`.
+1. Bakes the Croissant manifest (reusing the same machinery as `biotope add`).
+1. Stamps `dct:source` + `biotope:fetchedAt` provenance on the manifest.
+1. Stages `.biotope/` changes in Git.
+
+## v1 scope for `--crawl`
+
+Static HTML only. JS rendering, deep recursive crawls beyond the seeded depth,
+cloud-storage transports, and authentication are deliberately out of scope and
+tracked as follow-up issues.
+
+::: biotope.commands.get

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,10 +24,12 @@ APIs, CLI flags, and config-file layouts will change. End-user docs come after t
 
 !!! tip "Prefer a worked end-to-end example?"
 
-    The [**Tutorial**](tutorial.md) walks through building a real knowledge graph
-    from public airport/flight data in ~15 minutes. It's the most up-to-date
-    onboarding path and the source of truth for the recommended workflow
-    (`init` → `get` → `add` → `queue` → `map` → `build`).
+```
+The [**Tutorial**](tutorial.md) walks through building a real knowledge graph
+from public airport/flight data in ~15 minutes. It's the most up-to-date
+onboarding path and the source of truth for the recommended workflow
+(`init` → `get` → `add` → `queue` → `map` → `build`).
+```
 
 ```bash
 uv pip install biotope
@@ -70,8 +72,8 @@ All semantic decisions (which record set, which fields, which transforms) are ma
 
 ### Data acquisition + tracking
 
-- `biotope get <url>` — download a file (optionally into `--output-dir`) and, unless `--no-add`, track it.
-- `biotope add <path>` — stage data files or rooted directories; baker writes the Croissant entry under `.biotope/datasets/`. `--derived-from` records provenance for human/agent-extracted derivatives. For curated metadata that doesn't fit as CLI flags (descriptions, citations, per–record-set fields), `add` also drops a `.biotope.yaml` scaffold next to the dataset — review it, then run `biotope annotate apply <dir>` to merge it into the manifest.
+- `biotope get <source>` — universal ingress verb: copy/download a local file, directory, or URL into the project (or `--crawl` a website) and bake its manifest, recording `dct:source` + a fetch timestamp. Lands under `--into` (default `data`); `--no-add` skips tracking.
+- `biotope add <path>` — register data **already in the tree** (e.g. derived artifacts); baker writes the Croissant entry under `.biotope/datasets/`. `--derived-from` records provenance for human/agent-extracted derivatives. For curated metadata that doesn't fit as CLI flags (descriptions, citations, per–record-set fields), `add` also drops a `.biotope.yaml` scaffold next to the dataset — review it, then run `biotope annotate apply <dir>` to merge it into the manifest.
 - `biotope mv` / `biotope rm` — move or untrack files and update metadata paths.
 - `biotope queue` — show every dataset grouped by pipeline state (`raw` / `processed` / `mapped`). The recommended dashboard during a build.
 - `biotope mark <dataset> <status>` — manually set a dataset's `biotope:status`.

--- a/mkdocs.nav.yml
+++ b/mkdocs.nav.yml
@@ -12,6 +12,7 @@ nav:
   - Cluster Compliance: cluster-compliance.md
   - Commands:
       - Init: api-docs/init.md
+      - Get: api-docs/get.md
       - Add: api-docs/add.md
       - Map: api-docs/map.md
       - Build: api-docs/build.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
   - Cluster Compliance: cluster-compliance.md
   - Commands:
       - Init: api-docs/init.md
+      - Get: api-docs/get.md
       - Add: api-docs/add.md
       - Map: api-docs/map.md
       - Build: api-docs/build.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     # requests >=2.32 pulls patched urllib3 >=2.7 and idna >=3.15 via its
     # current dependency floor, addressing GHSA-* alerts on those transitives.
     "requests>=2.32.0,<3",
+    # `biotope get --crawl` parses fetched HTML to discover same-host links.
+    "beautifulsoup4>=4.12,<5",
     "pydantic>=2.6,<3",
     "jinja2>=3.1.6,<4",
     "duckdb>=1.0,<2",

--- a/tests/commands/test_get.py
+++ b/tests/commands/test_get.py
@@ -113,6 +113,45 @@ def test_download_file_failure(mock_get, tmp_path):
     assert result is None
 
 
+@mock.patch("requests.get")
+def test_download_file_sanitizes_traversal_filename(mock_get, tmp_path):
+    """A malicious Content-Disposition must not escape the output directory."""
+    mock_resp = mock.Mock()
+    mock_resp.headers = {
+        "content-length": "4",
+        "Content-Disposition": 'attachment; filename="../../etc/evil"',
+    }
+    mock_resp.iter_content.return_value = [b"data"]
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    output_dir = tmp_path / "downloads"
+    output_dir.mkdir()
+    result = download_file("https://example.com/x", output_dir)
+
+    assert result is not None
+    assert result.parent == output_dir
+    assert result.name == "evil"
+    assert not (tmp_path / "etc" / "evil").exists()
+
+
+@mock.patch("requests.get")
+def test_download_file_empty_basename_fallback(mock_get, tmp_path):
+    """A URL with no filename falls back to a safe default name."""
+    mock_resp = mock.Mock()
+    mock_resp.headers = {"content-length": "4"}
+    mock_resp.iter_content.return_value = [b"data"]
+    mock_resp.raise_for_status.return_value = None
+    mock_get.return_value = mock_resp
+
+    output_dir = tmp_path / "downloads"
+    output_dir.mkdir()
+    result = download_file("https://example.com/", output_dir)
+
+    assert result is not None
+    assert result.name == "downloaded_file"
+
+
 def test_find_biotope_root(biotope_project):
     """Test finding biotope project root."""
     # Test from project root
@@ -177,6 +216,10 @@ def test_call_biotope_add_success(mock_stage, mock_add, biotope_project):
             "legal_obligations": None,
             "collaboration_partner": None,
             "rai_fields": {},
+            "status_override": None,
+            "derived_from": [],
+            "source": None,
+            "fetched_at": None,
         },
     )
     mock_stage.assert_called_once_with(biotope_project)

--- a/tests/commands/test_get_ingress.py
+++ b/tests/commands/test_get_ingress.py
@@ -1,0 +1,349 @@
+"""Tests for the generalised `biotope get` ingress verb (issue #22).
+
+Covers local file/directory copy-and-bake, the website-scrape path, source
+provenance stamping, and the dispatch guards. The pre-existing URL-download
+behaviour is covered by tests/commands/test_get.py.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from biotope.commands.get import get
+from biotope.metadata import FETCHED_AT_KEY, SOURCE_KEY
+from biotope.scrape import ScrapeResult, ScrapedPage
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture
+def biotope_project(tmp_path: Path) -> Path:
+    """A real git-backed biotope project at <tmp>/project."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    biotope_dir = project_dir / ".biotope"
+    (biotope_dir / "datasets").mkdir(parents=True)
+    (biotope_dir / "config.yaml").write_text("project_name: test_project\n")
+    subprocess.run(["git", "init"], cwd=project_dir, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=project_dir, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=project_dir, check=True)
+    return project_dir
+
+
+@pytest.fixture
+def external_file(tmp_path: Path) -> Path:
+    """A CSV file living *outside* the project tree."""
+    src = tmp_path / "external" / "genes.csv"
+    src.parent.mkdir(parents=True)
+    src.write_text("GeneID,Expression\nBRCA1,12.5\nTP53,8.7\n")
+    return src
+
+
+@pytest.fixture
+def external_dir(tmp_path: Path) -> Path:
+    """A directory of files living *outside* the project tree."""
+    root = tmp_path / "external" / "source_pull"
+    (root / "sub").mkdir(parents=True)
+    (root / "a.csv").write_text("col1,col2\n1,2\n3,4\n")
+    (root / "sub" / "b.csv").write_text("x,y\n5,6\n")
+    return root
+
+
+def _invoke(runner: CliRunner, biotope_project: Path, args: list[str]):
+    """Run `get` with the project root resolved (cwd-independent)."""
+    with mock.patch("biotope.commands.get.find_biotope_root", return_value=biotope_project):
+        return runner.invoke(get, args)
+
+
+def _only_manifest(biotope_project: Path) -> dict:
+    manifests = list((biotope_project / ".biotope" / "datasets").rglob("*.jsonld"))
+    assert len(manifests) == 1, manifests
+    return json.loads(manifests[0].read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Local file
+# --------------------------------------------------------------------------- #
+
+
+def test_get_local_file_copies_and_bakes(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file)])
+    assert result.exit_code == 0, result.output
+
+    copied = biotope_project / "data" / "genes.csv"
+    assert copied.exists()
+    assert copied.read_text() == external_file.read_text()
+
+    metadata = _only_manifest(biotope_project)
+    assert metadata[SOURCE_KEY] == str(external_file.resolve())
+    assert FETCHED_AT_KEY in metadata
+    assert metadata["distribution"][0]["name"] == "genes.csv"
+
+
+def test_get_local_file_status_override(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--status", "raw"])
+    assert result.exit_code == 0, result.output
+    assert _only_manifest(biotope_project)["biotope:status"] == "raw"
+
+
+def test_get_local_file_no_add(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--no-add"])
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "data" / "genes.csv").exists()
+    assert not list((biotope_project / ".biotope" / "datasets").rglob("*.jsonld"))
+    assert "To add to biotope project" in result.output
+
+
+def test_get_local_file_custom_into(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--into", "data/raw"])
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "data" / "raw" / "genes.csv").exists()
+
+
+def test_get_local_file_output_dir_alias(runner, biotope_project, external_file):
+    """The legacy --output-dir flag still routes to --into."""
+    result = _invoke(runner, biotope_project, [str(external_file), "--output-dir", "inputs"])
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "inputs" / "genes.csv").exists()
+
+
+def test_get_local_file_metadata_overrides(runner, biotope_project, external_file):
+    result = _invoke(
+        runner,
+        biotope_project,
+        [str(external_file), "--license", "CC-BY-4.0", "--creator", "Source Org"],
+    )
+    assert result.exit_code == 0, result.output
+    metadata = _only_manifest(biotope_project)
+    assert metadata["license"] == "CC-BY-4.0"
+    assert metadata["creator"]["name"] == "Source Org"
+
+
+# --------------------------------------------------------------------------- #
+# Local directory
+# --------------------------------------------------------------------------- #
+
+
+def test_get_local_dir_copies_and_bakes(runner, biotope_project, external_dir):
+    result = _invoke(runner, biotope_project, [str(external_dir)])
+    assert result.exit_code == 0, result.output
+
+    assert (biotope_project / "data" / "source_pull" / "a.csv").exists()
+    assert (biotope_project / "data" / "source_pull" / "sub" / "b.csv").exists()
+    # A directory ingest writes one composite manifest + a review scaffold.
+    assert (biotope_project / "data" / "source_pull" / ".biotope.yaml").exists()
+
+    manifest = biotope_project / ".biotope" / "datasets" / "data" / "source_pull.jsonld"
+    assert manifest.exists()
+    metadata = json.loads(manifest.read_text())
+    assert metadata[SOURCE_KEY] == str(external_dir.resolve())
+    assert FETCHED_AT_KEY in metadata
+
+
+def test_get_local_dir_no_add(runner, biotope_project, external_dir):
+    result = _invoke(runner, biotope_project, [str(external_dir), "--no-add"])
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "data" / "source_pull" / "a.csv").exists()
+    assert not list((biotope_project / ".biotope" / "datasets").rglob("*.jsonld"))
+
+
+# --------------------------------------------------------------------------- #
+# Dispatch guards
+# --------------------------------------------------------------------------- #
+
+
+def test_get_unsupported_scheme_aborts(runner, biotope_project):
+    result = _invoke(runner, biotope_project, ["s3://bucket/key.csv"])
+    assert result.exit_code != 0
+    assert "Unsupported source" in result.output
+
+
+def test_get_crawl_requires_http(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--crawl"])
+    assert result.exit_code != 0
+    assert "--crawl requires an http(s) URL" in result.output
+
+
+def test_get_source_not_found_aborts(runner, biotope_project, tmp_path):
+    missing = tmp_path / "nope.csv"
+    result = _invoke(runner, biotope_project, [str(missing)])
+    assert result.exit_code != 0
+    assert "Source not found" in result.output
+
+
+def test_get_source_already_in_project_aborts(runner, biotope_project):
+    inside = biotope_project / "data" / "already.csv"
+    inside.parent.mkdir(parents=True)
+    inside.write_text("a,b\n1,2\n")
+    result = _invoke(runner, biotope_project, [str(inside)])
+    assert result.exit_code != 0
+    assert "already inside the project" in result.output
+    assert "biotope add" in result.output
+
+
+# --------------------------------------------------------------------------- #
+# Website scrape
+# --------------------------------------------------------------------------- #
+
+
+def _fake_crawl_two_pages(seed_url: str, dest_dir: Path, **_kwargs) -> ScrapeResult:
+    """Stand in for scrape.crawl: write two HTML pages, report them."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    (dest_dir / "index.html").write_text("<html>home</html>")
+    (dest_dir / "topic").mkdir(exist_ok=True)
+    (dest_dir / "topic" / "a.html").write_text("<html>a</html>")
+    return ScrapeResult(
+        host="example.com",
+        pages=[
+            ScrapedPage(url="https://example.com/", relpath=Path("index.html")),
+            ScrapedPage(url="https://example.com/topic/a", relpath=Path("topic/a.html")),
+        ],
+        skipped=[("https://example.com/blocked", "blocked by robots.txt")],
+    )
+
+
+def test_get_scrape_bakes_manifest_with_per_page_source(runner, biotope_project):
+    with mock.patch("biotope.commands.get.crawl", side_effect=_fake_crawl_two_pages):
+        result = _invoke(
+            runner,
+            biotope_project,
+            ["https://example.com/", "--crawl", "--depth", "1"],
+        )
+    assert result.exit_code == 0, result.output
+
+    manifest = biotope_project / ".biotope" / "datasets" / "data" / "example.com.jsonld"
+    assert manifest.exists()
+    metadata = json.loads(manifest.read_text())
+
+    # Dataset-level provenance points at the seed; status defaults to raw (HTML).
+    assert metadata[SOURCE_KEY] == "https://example.com/"
+    assert metadata["biotope:status"] == "raw"
+
+    # Each page carries its own source URL inline.
+    by_url = {d[SOURCE_KEY] for d in metadata["distribution"]}
+    assert by_url == {"https://example.com/", "https://example.com/topic/a"}
+
+
+def test_get_scrape_no_add(runner, biotope_project):
+    with mock.patch("biotope.commands.get.crawl", side_effect=_fake_crawl_two_pages):
+        result = _invoke(
+            runner,
+            biotope_project,
+            ["https://example.com/", "--crawl", "--no-add"],
+        )
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "data" / "example.com" / "index.html").exists()
+    assert not list((biotope_project / ".biotope" / "datasets").rglob("*.jsonld"))
+
+
+def test_get_scrape_no_pages_aborts(runner, biotope_project):
+    def _empty_crawl(seed_url, dest_dir, **_kwargs):
+        return ScrapeResult(host="example.com", pages=[], skipped=[("https://example.com/x", "fetch error: boom")])
+
+    with mock.patch("biotope.commands.get.crawl", side_effect=_empty_crawl):
+        result = _invoke(runner, biotope_project, ["https://example.com/", "--crawl"])
+    assert result.exit_code != 0
+    assert "No pages saved" in result.output
+
+
+def test_get_scrape_status_override(runner, biotope_project):
+    with mock.patch("biotope.commands.get.crawl", side_effect=_fake_crawl_two_pages):
+        result = _invoke(runner, biotope_project, ["https://example.com/", "--crawl", "--status", "processed"])
+    assert result.exit_code == 0, result.output
+    manifest = biotope_project / ".biotope" / "datasets" / "data" / "example.com.jsonld"
+    assert json.loads(manifest.read_text())["biotope:status"] == "processed"
+
+
+def test_scrape_dataset_addressable_by_ref(runner, biotope_project):
+    """The dotted-host dataset must resolve via mark/derived-from style refs."""
+    from biotope.commands.add import _resolve_dataset_ref
+
+    with mock.patch("biotope.commands.get.crawl", side_effect=_fake_crawl_two_pages):
+        _invoke(runner, biotope_project, ["https://example.com/", "--crawl"])
+
+    # Bare canonical id and the data-path form (the with_suffix bug) both resolve.
+    assert _resolve_dataset_ref("data/example.com", biotope_project) == "data/example.com"
+    assert _resolve_dataset_ref(str(biotope_project / "data" / "example.com"), biotope_project) == "data/example.com"
+
+
+# --------------------------------------------------------------------------- #
+# Provenance + containment + autoinit
+# --------------------------------------------------------------------------- #
+
+
+def test_get_derived_from_records_provenance(runner, biotope_project, external_file, tmp_path):
+    base = tmp_path / "ext_base" / "base.csv"
+    base.parent.mkdir(parents=True)
+    base.write_text("a,b\n1,2\n")
+    _invoke(runner, biotope_project, [str(base)])  # → data/base.csv, id "data/base"
+
+    result = _invoke(runner, biotope_project, [str(external_file), "--derived-from", "data/base"])
+    assert result.exit_code == 0, result.output
+    metadata = json.loads((biotope_project / ".biotope" / "datasets" / "data" / "genes.jsonld").read_text())
+    assert any(entry.get("@id") == "data/base" for entry in metadata["prov:wasDerivedFrom"])
+
+
+def test_get_derived_from_bad_ref_aborts(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--derived-from", "does/not/exist"])
+    assert result.exit_code != 0
+
+
+def test_get_into_absolute_rejected(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--into", "/tmp/escape"])
+    assert result.exit_code != 0
+    assert "--into" in result.output
+
+
+def test_get_into_traversal_rejected(runner, biotope_project, external_file):
+    result = _invoke(runner, biotope_project, [str(external_file), "--into", "../escape"])
+    assert result.exit_code != 0
+
+
+def test_get_local_file_via_file_url(runner, biotope_project, external_file):
+    url = "file://" + str(external_file.resolve())
+    result = _invoke(runner, biotope_project, [url])
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "data" / "genes.csv").exists()
+    assert _only_manifest(biotope_project)[SOURCE_KEY] == str(external_file.resolve())
+
+
+def test_get_local_dir_skips_symlinks(runner, biotope_project, tmp_path):
+    src = tmp_path / "ext_pull" / "pull"
+    src.mkdir(parents=True)
+    (src / "real.csv").write_text("a,b\n1,2\n")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOPSECRET")
+    (src / "link.txt").symlink_to(secret)
+
+    result = _invoke(runner, biotope_project, [str(src)])
+    assert result.exit_code == 0, result.output
+    assert (biotope_project / "data" / "pull" / "real.csv").exists()
+    # The symlink (and its external target's content) must not be copied in.
+    assert not (biotope_project / "data" / "pull" / "link.txt").exists()
+    assert "symlink" in result.output.lower()
+
+
+def test_get_autoinit_with_local_source(runner, tmp_path):
+    """Outside a project, get scaffolds one and lands a local file at the new root."""
+    ext = tmp_path / "ext_auto" / "genes.csv"
+    ext.parent.mkdir(parents=True)
+    ext.write_text("GeneID,Expression\nBRCA1,12.5\n")
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(get, [str(ext)])
+        assert result.exit_code == 0, result.output
+        assert Path("data/.biotope").is_dir()
+        # autoinit lands data at the new root (not under data/data/).
+        assert Path("data/genes.csv").exists()
+        manifests = list(Path("data/.biotope/datasets").rglob("*.jsonld"))
+        assert len(manifests) == 1
+        assert json.loads(manifests[0].read_text())[SOURCE_KEY] == str(ext.resolve())

--- a/tests/unit/test_metadata_status.py
+++ b/tests/unit/test_metadata_status.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import pytest
 
 from biotope.metadata import (
+    FETCHED_AT_KEY,
+    SOURCE_KEY,
     STATUS_MAPPED,
     STATUS_PROCESSED,
     STATUS_RAW,
     add_derived_from,
     classify_status_from_baker,
     get_derived_from,
+    get_source,
     get_status,
     merge_metadata,
+    set_source,
     set_status,
 )
 
@@ -76,3 +80,33 @@ def test_merge_metadata_includes_biotope_and_prov_namespaces():
     ctx = merge_metadata({})["@context"]
     assert ctx["biotope"].startswith("https://")
     assert ctx["prov"] == "http://www.w3.org/ns/prov#"
+
+
+def test_set_source_records_origin_and_timestamp():
+    """`biotope get` stamps where data came from + when it was fetched."""
+    metadata: dict = {}
+    set_source(metadata, "https://example.com/data.csv", "2026-06-01T00:00:00+00:00")
+    assert metadata[SOURCE_KEY] == "https://example.com/data.csv"
+    assert metadata[FETCHED_AT_KEY] == "2026-06-01T00:00:00+00:00"
+    assert get_source(metadata) == "https://example.com/data.csv"
+
+
+def test_set_source_leaves_clean_when_empty():
+    """Plain `biotope add` (no external origin) must not add ingress fields."""
+    metadata: dict = {}
+    set_source(metadata, None)
+    assert SOURCE_KEY not in metadata
+    assert FETCHED_AT_KEY not in metadata
+    assert get_source(metadata) is None
+
+
+def test_set_source_without_timestamp():
+    metadata: dict = {}
+    set_source(metadata, "/scratch/data/foo.csv")
+    assert metadata[SOURCE_KEY] == "/scratch/data/foo.csv"
+    assert FETCHED_AT_KEY not in metadata
+
+
+def test_get_source_accepts_node_form():
+    assert get_source({SOURCE_KEY: {"@id": "https://e.com/x"}}) == "https://e.com/x"
+    assert get_source({}) is None

--- a/tests/unit/test_scrape.py
+++ b/tests/unit/test_scrape.py
@@ -1,0 +1,339 @@
+"""Tests for the bounded static-HTML crawler in biotope/scrape.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+
+from biotope import scrape
+from biotope.scrape import (
+    ScrapeError,
+    ScrapeResult,
+    crawl,
+    extract_links,
+    normalize_url,
+    url_to_relpath,
+)
+
+
+class _Resp:
+    """Minimal stand-in for requests.Response."""
+
+    def __init__(
+        self,
+        text: str,
+        status: int = 200,
+        content_type: str = "text/html",
+        final_url: str | None = None,
+    ) -> None:
+        self.text = text
+        self.content = text.encode("utf-8")
+        self.status_code = status
+        self.headers = {"Content-Type": content_type}
+        # Mirrors requests.Response.url (the URL after any redirects).
+        self.url = final_url or ""
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code}")
+
+
+class _StubSession:
+    """A requests.Session stub serving a fixed URL→response map."""
+
+    def __init__(self, pages: dict[str, _Resp]) -> None:
+        self.pages = pages
+        self.requested: list[str] = []
+
+    def get(self, url: str, **_kwargs) -> _Resp:
+        self.requested.append(url)
+        value = self.pages.get(url)
+        if value is None:
+            resp = _Resp("not found", status=404)
+        elif isinstance(value, _Resp):
+            resp = value
+        else:
+            resp = _Resp(value)  # bare HTML string → 200 text/html
+        # Default the final URL to the requested one (no redirect) unless the
+        # fixture explicitly set a redirect target.
+        if not resp.url:
+            resp.url = url
+        return resp
+
+
+def _html(*hrefs: str) -> str:
+    anchors = " ".join(f'<a href="{h}">link</a>' for h in hrefs)
+    return f"<html><body>{anchors}</body></html>"
+
+
+# --------------------------------------------------------------------------- #
+# url_to_relpath
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://e.com/", "index.html"),
+        ("https://e.com", "index.html"),
+        ("https://e.com/topic/", "topic/index.html"),
+        ("https://e.com/topic/page", "topic/page.html"),
+        ("https://e.com/a/b.html", "a/b.html"),
+        ("https://e.com/a/b.htm", "a/b.htm"),
+    ],
+)
+def test_url_to_relpath(url: str, expected: str) -> None:
+    assert url_to_relpath(url) == expected
+
+
+def test_url_to_relpath_disambiguates_query() -> None:
+    a = url_to_relpath("https://e.com/list?page=1")
+    b = url_to_relpath("https://e.com/list?page=2")
+    assert a != b
+    assert a.endswith(".html") and b.endswith(".html")
+
+
+def test_normalize_url_strips_fragment() -> None:
+    assert normalize_url("https://e.com/p#section") == "https://e.com/p"
+
+
+# --------------------------------------------------------------------------- #
+# extract_links
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_links_resolves_and_filters() -> None:
+    html = _html("/a", "b.html", "#frag", "mailto:x@y.com", "javascript:void(0)", "https://other.com/z")
+    links = extract_links(html, "https://e.com/topic/")
+    assert "https://e.com/a" in links
+    assert "https://e.com/topic/b.html" in links
+    assert "https://other.com/z" in links
+    # Non-navigational schemes are dropped.
+    assert not any(link.startswith(("mailto:", "javascript:")) for link in links)
+    assert not any("#frag" in link for link in links)
+
+
+def test_extract_links_dedupes() -> None:
+    html = _html("/a", "/a", "/a#x")
+    links = extract_links(html, "https://e.com/")
+    assert links.count("https://e.com/a") == 1
+
+
+# --------------------------------------------------------------------------- #
+# crawl
+# --------------------------------------------------------------------------- #
+
+
+def test_crawl_rejects_non_http_seed(tmp_path: Path) -> None:
+    with pytest.raises(ScrapeError, match="http"):
+        crawl("/local/path", tmp_path, session=_StubSession({}))
+
+
+def test_crawl_depth_zero_saves_only_seed(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/a"),
+        "https://e.com/a": _html(),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=0, rate=0, session=_StubSession(pages))
+    assert [p.url for p in result.pages] == ["https://e.com/"]
+    assert (tmp_path / "index.html").exists()
+
+
+def test_crawl_breadth_first_same_host(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/topic/": _html("/topic/a", "b.html", "https://other.com/x"),
+        "https://e.com/topic/a": _html("../deep/c"),
+        "https://e.com/topic/b.html": _html(),
+        "https://e.com/deep/c": _html(),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    session = _StubSession(pages)
+    result = crawl("https://e.com/topic/", tmp_path, depth=2, rate=0, session=session)
+
+    saved = {p.url for p in result.pages}
+    assert saved == {
+        "https://e.com/topic/",
+        "https://e.com/topic/a",
+        "https://e.com/topic/b.html",
+        "https://e.com/deep/c",
+    }
+    # Cross-host link is never fetched.
+    assert "https://other.com/x" not in session.requested
+    assert result.host == "e.com"
+
+
+def test_crawl_respects_robots(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/secret", "/ok"),
+        "https://e.com/ok": _html(),
+        "https://e.com/secret": _html(),
+        "https://e.com/robots.txt": _Resp("User-agent: *\nDisallow: /secret\n", content_type="text/plain"),
+    }
+    session = _StubSession(pages)
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=session)
+
+    saved = {p.url for p in result.pages}
+    assert "https://e.com/ok" in saved
+    assert "https://e.com/secret" not in saved
+    assert "https://e.com/secret" not in session.requested
+    assert any("robots" in reason for _url, reason in result.skipped)
+
+
+def test_crawl_ignore_robots(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/secret"),
+        "https://e.com/secret": _html(),
+        "https://e.com/robots.txt": _Resp("User-agent: *\nDisallow: /secret\n", content_type="text/plain"),
+    }
+    session = _StubSession(pages)
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, respect_robots=False, session=session)
+    assert "https://e.com/secret" in {p.url for p in result.pages}
+    # robots.txt is not even fetched when ignored.
+    assert "https://e.com/robots.txt" not in session.requested
+
+
+def test_crawl_skips_non_html(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/data.csv"),
+        "https://e.com/data.csv": _Resp("a,b\n1,2", content_type="text/csv"),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    assert [p.url for p in result.pages] == ["https://e.com/"]
+    assert any("non-HTML" in reason for _url, reason in result.skipped)
+
+
+def test_crawl_honours_max_pages(tmp_path: Path) -> None:
+    pages = {"https://e.com/robots.txt": _Resp("", status=404)}
+    # A fan of 10 same-host links from the seed.
+    seed_links = [f"/p{i}" for i in range(10)]
+    pages["https://e.com/"] = _html(*seed_links)
+    for i in range(10):
+        pages[f"https://e.com/p{i}"] = _html()
+    result = crawl("https://e.com/", tmp_path, depth=1, max_pages=3, rate=0, session=_StubSession(pages))
+    assert len(result.pages) == 3
+
+
+def test_crawl_skips_failed_fetch(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/missing"),
+        "https://e.com/missing": _Resp("nope", status=500),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    assert [p.url for p in result.pages] == ["https://e.com/"]
+    assert any("fetch error" in reason for _url, reason in result.skipped)
+
+
+def test_crawl_rate_limit_sleeps(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/a"),
+        "https://e.com/a": _html(),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    with mock.patch.object(scrape.time, "sleep") as sleep:
+        crawl("https://e.com/", tmp_path, depth=1, rate=5.0, session=_StubSession(pages))
+    # With >1 page and a positive rate, at least one throttle sleep happens.
+    assert sleep.called
+
+
+def test_crawl_path_traversal_is_contained(tmp_path: Path) -> None:
+    # A server linking to encoded traversal must not escape the dest dir.
+    pages = {
+        "https://e.com/": _html("/../../etc/passwd"),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    # Nothing was written outside tmp_path.
+    escaped = tmp_path.parent / "etc" / "passwd"
+    assert not escaped.exists()
+
+
+def test_scrape_result_defaults() -> None:
+    result = ScrapeResult(host="e.com")
+    assert result.pages == []
+    assert result.skipped == []
+
+
+def test_crawl_dedupes_urls_collapsing_to_same_relpath(tmp_path: Path) -> None:
+    # /about and /about.html both map to about.html — only one should be saved.
+    pages = {
+        "https://e.com/": _html("/about", "/about.html"),
+        "https://e.com/about": _html(),
+        "https://e.com/about.html": _html(),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    relpaths = [str(p.relpath) for p in result.pages]
+    assert relpaths.count("about.html") == 1
+    assert any(reason == "duplicate path" for _url, reason in result.skipped)
+
+
+def test_crawl_honours_robots_crawl_delay(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/a"),
+        "https://e.com/a": _html(),
+        "https://e.com/robots.txt": _Resp("User-agent: *\nCrawl-delay: 5\n", content_type="text/plain"),
+    }
+    with mock.patch.object(scrape.time, "sleep") as sleep:
+        # Even with a fast --rate, the 5s crawl-delay should dominate the pace.
+        crawl("https://e.com/", tmp_path, depth=1, rate=1000.0, session=_StubSession(pages))
+    assert any(call.args and call.args[0] >= 4.5 for call in sleep.call_args_list)
+
+
+def test_crawl_skips_offhost_redirect(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/jump"),
+        # /jump redirects off-host; requests would expose this via response.url.
+        "https://e.com/jump": _Resp(_html(), final_url="https://evil.com/landing"),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    saved = {p.url for p in result.pages}
+    assert "https://evil.com/landing" not in saved
+    assert not (tmp_path / "landing.html").exists()
+    assert any("off-host" in reason for _url, reason in result.skipped)
+
+
+def test_crawl_follows_samehost_redirect_and_records_final_url(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/old"),
+        "https://e.com/old": _Resp(_html(), final_url="https://e.com/new"),
+        "https://e.com/robots.txt": _Resp("", status=404),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    saved = {p.url for p in result.pages}
+    # The page is saved under its final URL, not the requested one.
+    assert "https://e.com/new" in saved
+    assert (tmp_path / "new.html").exists()
+
+
+def test_crawl_5xx_robots_disallows_all(tmp_path: Path) -> None:
+    pages = {
+        "https://e.com/": _html("/a"),
+        "https://e.com/a": _html(),
+        "https://e.com/robots.txt": _Resp("oops", status=503),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_StubSession(pages))
+    assert result.pages == []
+    assert any("robots" in reason for _url, reason in result.skipped)
+
+
+def test_crawl_robots_network_failure_allows_all(tmp_path: Path) -> None:
+    class _RobotsBoom(_StubSession):
+        def get(self, url: str, **kwargs):
+            if url.endswith("/robots.txt"):
+                raise requests.ConnectionError("boom")
+            return super().get(url, **kwargs)
+
+    pages = {
+        "https://e.com/": _html("/a"),
+        "https://e.com/a": _html(),
+    }
+    result = crawl("https://e.com/", tmp_path, depth=1, rate=0, session=_RobotsBoom(pages))
+    # A transient robots fetch failure must not block the user-requested crawl.
+    assert {p.url for p in result.pages} == {"https://e.com/", "https://e.com/a"}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'win32'",
@@ -177,6 +177,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "biocypher"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -201,9 +214,10 @@ wheels = [
 
 [[package]]
 name = "biotope"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "biocypher" },
     { name = "click" },
     { name = "croissant-baker" },
@@ -228,6 +242,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12,<5" },
     { name = "biocypher", specifier = ">=0.14.0,<1" },
     { name = "bump2version", marker = "extra == 'dev'", specifier = ">=1.0.1" },
     { name = "click", specifier = ">=8.1.8,<9" },
@@ -2120,6 +2135,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/5e/70bdd9579b35003a489fc850b5047beeda26328053ebadc1fb60f320f7db/soundfile-0.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:03267c4e493315294834a0870f31dbb3b28a95561b80b134f0bd3cf2d5f0e618", size = 1313646, upload-time = "2025-01-25T09:16:54.872Z" },
     { url = "https://files.pythonhosted.org/packages/fe/df/8c11dc4dfceda14e3003bb81a0d0edcaaf0796dd7b4f826ea3e532146bba/soundfile-0.13.1-py2.py3-none-win32.whl", hash = "sha256:c734564fab7c5ddf8e9be5bf70bab68042cd17e9c214c06e365e20d64f9a69d5", size = 899881, upload-time = "2025-01-25T09:16:56.663Z" },
     { url = "https://files.pythonhosted.org/packages/14/e9/6b761de83277f2f02ded7e7ea6f07828ec78e4b229b80e4ca55dd205b9dc/soundfile-0.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:1e70a05a0626524a69e9f0f4dd2ec174b4e9567f4d8b6c11d38b5c289be36ee9", size = 1019162, upload-time = "2025-01-25T09:16:59.573Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Generalises `biotope get` beyond single-URL downloads. It now dispatches on source shape, local files, local directories, and bounded `--crawl` website scrapes, copying data into the project, baking the manifest, and recording source provenance (`dct:source` + fetch timestamp) in one shot.

- New `--into` and `--status` options; default destination is now `data/<basename>`
- New polite, bounded static-HTML crawler (adds `beautifulsoup4`)
- `biotope add` records external-source provenance on baked manifests

 fixes #22